### PR TITLE
Use standard 16 damage rolls for champions and update tests

### DIFF
--- a/src/damage/battle.ts
+++ b/src/damage/battle.ts
@@ -119,8 +119,7 @@ function getDamage(originalOpt: BattleStatus): DamageResult {
 		[modifyBySpreadDamage, modifyByWeather, modifyByCriticalHit],
 		pipeOperator,
 	);
-	// pokemon champions removed the smallest random number
-	const dmgRollCounts = originalOpt.isChampion ? 15 : 16;
+		const dmgRollCounts = 16;
 
 	const possibleDamages = modifyByRandomNum(
 		preRandomResult.operator,

--- a/test/damage/ability.test.ts
+++ b/test/damage/ability.test.ts
@@ -29,20 +29,20 @@ test("Supreme Overlord", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		87, 88, 88, 90, 91, 91, 93, 94, 94, 96, 97, 97, 99, 100, 102,
+		85, 87, 88, 88, 90, 91, 91, 93, 94, 94, 96, 97, 97, 99, 100, 102,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
 	kingGambit.ability = "Supreme Overlord 2";
 	const down2Actual = getDamangeNumberFromResult(battle.getDamage());
 	const down2Expected = [
-		94, 96, 97, 97, 99, 100, 102, 102, 103, 105, 106, 106, 108, 109, 111,
+		93, 94, 96, 97, 97, 99, 100, 102, 102, 103, 105, 106, 106, 108, 109, 111,
 	];
 	expect(down2Actual).toEqual(down2Expected);
 	kingGambit.ability = "Supreme Overlord 3";
 	const down3Actual = getDamangeNumberFromResult(battle.getDamage());
 	const down3Expected = [
-		102, 103, 105, 106, 108, 108, 109, 111, 112, 114, 114, 115, 117, 118, 120,
+		102, 102, 103, 105, 106, 108, 108, 109, 111, 112, 114, 114, 115, 117, 118, 120,
 	];
 	expect(down3Actual).toEqual(down3Expected);
 });
@@ -79,7 +79,7 @@ test("Liquid Voice", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116, 120,
+		102, 102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116, 120,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -105,7 +105,7 @@ test("Pixilate", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116, 120,
+		102, 102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116, 120,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -119,7 +119,7 @@ test("Pixilate", () => {
 	const nonNormalDamage = battle.getDamage();
 	const nonNormalActual = getDamangeNumberFromResult(nonNormalDamage);
 	const nonNormalExpected = [
-		28, 28, 29, 29, 29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33,
+		28, 28, 28, 29, 29, 29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33,
 	];
 	expect(nonNormalActual).toEqual(nonNormalExpected);
 	expect(nonNormalDamage.factors.attacker.ability).toBeUndefined();
@@ -140,7 +140,7 @@ test("Refrigerate", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
+		114, 114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -165,7 +165,7 @@ test("Aerilate", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		180, 180, 182, 186, 188, 188, 192, 194, 194, 198, 200, 200, 204, 206, 210,
+		176, 180, 180, 182, 186, 188, 188, 192, 194, 194, 198, 200, 200, 204, 206, 210,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -195,7 +195,7 @@ test("Galvanize", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134, 134, 138,
+		116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134, 134, 138,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -213,7 +213,7 @@ test("Dragonize", () => {
 	const battle = new Battle({ attacker, defender, move });
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
-	const expected = [74, 76, 76, 78, 78, 80, 80, 80, 82, 82, 84, 84, 86, 86, 88];
+	const expected = [74, 74, 76, 76, 78, 78, 80, 80, 80, 82, 82, 84, 84, 86, 86, 88];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
 });
@@ -237,7 +237,7 @@ test("Adaptability", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	const expected = [
-		108, 108, 110, 112, 112, 114, 114, 116, 118, 118, 120, 122, 122, 124, 126,
+		106, 108, 108, 110, 112, 112, 114, 114, 116, 118, 118, 120, 122, 122, 124, 126,
 	];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
@@ -257,7 +257,7 @@ test("Mega Sol: Fire move in Rain is treated as Sun (1.5x, not 0.5x)", () => {
 	expect(damage.factors.attacker.weather).toBe(true);
 	expect(damage.factors.defender.weather).toBeUndefined();
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		47, 47, 48, 48, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 55,
+		46, 47, 47, 48, 48, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 55,
 	]);
 });
 
@@ -275,7 +275,7 @@ test("Mega Sol: Water move in Rain is treated as Sun (0.5x, not 1.5x)", () => {
 	expect(damage.factors.defender.weather).toBe(true);
 	// base=37, *0.5=18, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		15, 15, 15, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 18,
+		15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 18,
 	]);
 });
 
@@ -300,7 +300,7 @@ test("Mega Sol: Weather Ball in Rain becomes Fire-type (not Water-type)", () => 
 	// bp doubles to 100 (Rain weather exists), Fire-in-Sun 1.5x → pre-type base 69
 	// Fire vs Fire = 0.5x → final rolls
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33, 33, 33, 34, 34,
+		29, 29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33, 33, 33, 34, 34,
 	]);
 });
 
@@ -317,7 +317,7 @@ test("Mega Sol: Solar Beam in Rain has full power (no 0.5x penalty)", () => {
 	const damage = battle.getDamage();
 	// Full 120bp: base=54, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		46, 46, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 52, 53, 54,
+		45, 46, 46, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 52, 53, 54,
 	]);
 });
 
@@ -334,7 +334,7 @@ test("Solar Beam in Rain WITHOUT Mega Sol still gets 0.5x penalty", () => {
 	const damage = battle.getDamage();
 	// Effective 60bp: base=28, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		24, 24, 24, 24, 25, 25, 25, 26, 26, 26, 26, 27, 27, 27, 28,
+		23, 24, 24, 24, 24, 25, 25, 25, 26, 26, 26, 26, 27, 27, 27, 28,
 	]);
 });
 
@@ -351,7 +351,7 @@ test("Sand still boosts Rock special defense without Mega Sol", () => {
 	const damage = battle.getDamage();
 	// Rock SpDef 1.5x in Sand: base=25, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25,
+		21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25,
 	]);
 });
 
@@ -368,7 +368,7 @@ test("Mega Sol: Rock-type defender does NOT get Sand special defense boost", () 
 	const damage = battle.getDamage();
 	// No defense boost (Mega Sol treats weather as Sun): base=37, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		31, 32, 32, 32, 33, 33, 34, 34, 34, 35, 35, 35, 36, 36, 37,
+		31, 31, 32, 32, 32, 33, 33, 34, 34, 34, 35, 35, 35, 36, 36, 37,
 	]);
 });
 
@@ -385,7 +385,7 @@ test("Snow still boosts Ice physical defense without Mega Sol", () => {
 	const damage = battle.getDamage();
 	// Ice PhyDef 1.5x in Snow: base=25, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25,
+		21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25,
 	]);
 });
 
@@ -402,7 +402,7 @@ test("Mega Sol: Ice-type defender does NOT get Snow physical defense boost", () 
 	const damage = battle.getDamage();
 	// No defense boost (Mega Sol treats weather as Sun): base=37, rolls 85%–100%
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		31, 32, 32, 32, 33, 33, 34, 34, 34, 35, 35, 35, 36, 36, 37,
+		31, 31, 32, 32, 32, 33, 33, 34, 34, 34, 35, 35, 35, 36, 36, 37,
 	]);
 });
 
@@ -428,7 +428,7 @@ test("Mega Sol: Weather Ball in clear skies becomes Fire-type at 100bp", () => {
 	// 100bp, Sun boost 1.5x, Fire vs Fire 0.5x
 	// base=46, *1.5=69, random [58..69], *0.5 each:
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33, 33, 33, 34, 34,
+		29, 29, 30, 30, 30, 31, 31, 31, 32, 32, 32, 33, 33, 33, 34, 34,
 	]);
 });
 
@@ -456,7 +456,7 @@ test("Scrappy: Normal move against Ghost-type ignores immunity", () => {
 	// Without Scrappy, Normal vs Ghost = 0x (always misses)
 	// With Scrappy, Normal vs Ghost = 1x (neutral)
 	const actual = getDamangeNumberFromResult(damage);
-	const expected = [79, 79, 81, 82, 82, 84, 85, 85, 87, 87, 88, 90, 90, 91, 93];
+	const expected = [78, 79, 79, 81, 82, 82, 84, 85, 85, 87, 87, 88, 90, 90, 91, 93];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
 
@@ -469,7 +469,7 @@ test("Scrappy: Normal move against Ghost-type ignores immunity", () => {
 	const damage2 = battle.getDamage();
 	const actual2 = getDamangeNumberFromResult(damage2);
 	const expected2 = [
-		24, 24, 25, 25, 26, 26, 26, 27, 27, 27, 27, 27, 28, 28, 29,
+		24, 24, 24, 25, 25, 26, 26, 26, 27, 27, 27, 27, 27, 28, 28, 29,
 	];
 	expect(actual2).toEqual(expected2);
 	expect(damage2.factors.attacker.ability).toEqual(true);
@@ -496,7 +496,7 @@ test("Scrappy: Fighting move against Ghost-type ignores immunity", () => {
 	});
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
-	const expected = [16, 16, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 19, 19, 19];
+	const expected = [16, 16, 16, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 19, 19, 19];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.attacker.ability).toEqual(true);
 	const aegislash = genTestMon({
@@ -507,7 +507,7 @@ test("Scrappy: Fighting move against Ghost-type ignores immunity", () => {
 	const damage2 = battle.getDamage();
 	const actual2 = getDamangeNumberFromResult(damage2);
 	const expected2 = [
-		42, 42, 44, 44, 44, 44, 46, 46, 46, 46, 48, 48, 48, 48, 50,
+		42, 42, 42, 44, 44, 44, 44, 46, 46, 46, 46, 48, 48, 48, 48, 50,
 	];
 	expect(actual2).toEqual(expected2);
 	expect(damage2.factors.attacker.ability).toEqual(true);

--- a/test/damage/aura.test.ts
+++ b/test/damage/aura.test.ts
@@ -27,7 +27,7 @@ test("Pixilate with Fairy Aura", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	expect(actual).toEqual([
-		132, 134, 134, 138, 138, 140, 140, 144, 144, 146, 146, 150, 150, 152, 156,
+		132, 132, 134, 134, 138, 138, 140, 140, 144, 144, 146, 146, 150, 150, 152, 156,
 	]);
 	expect(damage.factors.field?.aura).toEqual(true);
 	expect(damage.factors.attacker?.ability).toEqual(true);
@@ -56,7 +56,7 @@ test("Fairy move under Fairy Aura", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	expect(actual).toEqual([
-		162, 162, 164, 168, 168, 170, 170, 174, 176, 176, 180, 182, 182, 186, 188,
+		158, 162, 162, 164, 168, 168, 170, 170, 174, 176, 176, 180, 182, 182, 186, 188,
 	]);
 	expect(damage.factors.field?.aura).toEqual(true);
 });
@@ -84,7 +84,7 @@ test("Dark move under Dark Aura", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	expect(actual).toEqual([
-		40, 40, 41, 42, 42, 42, 42, 43, 44, 44, 45, 45, 45, 46, 47,
+		39, 40, 40, 41, 42, 42, 42, 42, 43, 44, 44, 45, 45, 45, 46, 47,
 	]);
 	expect(damage.factors.field?.aura).toEqual(true);
 });
@@ -112,7 +112,7 @@ test("Aura Break present (interaction test)", () => {
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
 	expect(actual).toEqual([
-		90, 92, 92, 96, 96, 96, 98, 98, 98, 102, 102, 102, 104, 104, 108,
+		90, 90, 92, 92, 96, 96, 96, 98, 98, 98, 102, 102, 102, 104, 104, 108,
 	]);
 	expect(damage.factors.field?.aura).toEqual(true);
 });

--- a/test/damage/basic.test.ts
+++ b/test/damage/basic.test.ts
@@ -26,7 +26,7 @@ test("test STAB", () => {
 		base: 90,
 		category: "Special",
 	});
-	const expected = [59, 60, 60, 61, 62, 62, 63, 64, 64, 65, 66, 66, 67, 68, 69];
+	const expected = [58, 59, 60, 60, 61, 62, 62, 63, 64, 64, 65, 66, 66, 67, 68, 69];
 	const battle = new Battle({
 		attacker: flutterMane,
 		defender: incineroar,
@@ -42,7 +42,7 @@ test("test STAB", () => {
 	});
 	battle.move = moonblast;
 	const expectedWithSTAB = [
-		93, 94, 96, 96, 97, 99, 100, 100, 102, 103, 105, 105, 106, 108, 109,
+		93, 93, 94, 96, 96, 97, 99, 100, 100, 102, 103, 105, 105, 106, 108, 109,
 	];
 	const actualWithSTAB = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualWithSTAB)).toEqual(expectedWithSTAB);
@@ -76,7 +76,7 @@ test("test offensive tera", () => {
 	battle.move = moonblast;
 	const actual = battle.getDamage();
 	const expected = [
-		102, 104, 104, 106, 108, 108, 110, 110, 112, 114, 114, 116, 116, 118, 120,
+		102, 102, 104, 104, 106, 108, 108, 110, 110, 112, 114, 114, 116, 116, 118, 120,
 	];
 	expect(getDamangeNumberFromResult(actual)).toEqual(expected);
 	expect(actual.factors.attacker.isTera).toBe(true);
@@ -89,7 +89,7 @@ test("test offensive tera", () => {
 	});
 	battle.move = thunderbolt;
 	const expectedTbolt = [
-		73, 73, 75, 75, 76, 76, 78, 79, 79, 81, 81, 82, 82, 84, 85,
+		72, 73, 73, 75, 75, 76, 76, 78, 79, 79, 81, 81, 82, 82, 84, 85,
 	];
 	const actualTbolt = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualTbolt)).toEqual(expectedTbolt);
@@ -125,7 +125,7 @@ test("defensive tera", () => {
 	});
 	const damage = battle.getDamage();
 	const actual = getDamangeNumberFromResult(damage);
-	const expected = [38, 39, 39, 39, 40, 40, 41, 41, 42, 42, 42, 43, 43, 44, 45];
+	const expected = [38, 38, 39, 39, 39, 40, 40, 41, 41, 42, 42, 42, 43, 43, 44, 45];
 	expect(actual).toEqual(expected);
 	expect(damage.factors.defender.isTera).toBe(true);
 });

--- a/test/damage/champion.test.ts
+++ b/test/damage/champion.test.ts
@@ -3,8 +3,7 @@ import { createMove } from "../../src";
 import { Battle } from "../../src/damage/battle";
 import { genTestMon, getDamangeNumberFromResult } from "./utils";
 
-test("champion (default) vs non-champion damage rolls comparison", () => {
-	// Setup test Pokémon
+test("champion (default) uses standard 16 damage rolls", () => {
 	const attacker = genTestMon({
 		types: ["Normal"],
 		baseStat: {
@@ -29,20 +28,11 @@ test("champion (default) vs non-champion damage rolls comparison", () => {
 		category: "Special",
 	});
 
-	// Test champion (15 rolls) - default
 	const battleChampion = new Battle({
 		attacker,
 		defender,
 		move,
 	});
-
-	const damageChampion = battleChampion.getDamage();
-	const rollsChampion = getDamangeNumberFromResult(damageChampion);
-
-	// Champion should have 15 rolls (excludes the minimum)
-	expect(rollsChampion).toHaveLength(15);
-
-	// Test non-champion (16 rolls)
 	const battleNonChampion = new Battle({
 		attacker,
 		defender,
@@ -50,150 +40,56 @@ test("champion (default) vs non-champion damage rolls comparison", () => {
 		isChampion: false,
 	});
 
-	const damageNonChampion = battleNonChampion.getDamage();
-	const rollsNonChampion = getDamangeNumberFromResult(damageNonChampion);
-
-	// Non-champion should have 16 rolls
-	expect(rollsNonChampion).toHaveLength(16);
-	// Champion rolls should be the second to 16 of non-champion rolls
-	expect(rollsChampion).toEqual(rollsNonChampion.slice(1, 16));
-});
-
-test("champion KO chance calculation with 15 rolls", () => {
-	const attacker = genTestMon({
-		types: ["Normal"],
-		baseStat: {
-			specialAttack: 150,
-		},
-		effortValues: {
-			specialAttack: 252,
-		},
-	});
-
-	const defender = genTestMon({
-		types: ["Normal"],
-		stats: {
-			hp: 100,
-			specialDefense: 50,
-		},
-	});
-
-	const move = createMove({
-		type: "Normal",
-		base: 100,
-		category: "Special",
-	});
-
-	const battleChampion = new Battle({
-		attacker,
-		defender,
-		move,
-		isChampion: true,
-	});
-
-	const damageChampion = battleChampion.getDamage();
-
-	// With 15 rolls and higher damage, KO chance should be calculated correctly
-	// based on 15 rolls instead of 16
-	expect(damageChampion.koChance).toBeGreaterThanOrEqual(0);
-	expect(damageChampion.koChance).toBeLessThanOrEqual(100);
-
-	// Verify rolls array has 15 elements
-	expect(damageChampion.rolls).toHaveLength(15);
-});
-
-test("non-champion KO chance calculation with 16 rolls", () => {
-	const attacker = genTestMon({
-		types: ["Normal"],
-		baseStat: {
-			specialAttack: 150,
-		},
-		effortValues: {
-			specialAttack: 252,
-		},
-	});
-
-	const defender = genTestMon({
-		types: ["Normal"],
-		stats: {
-			hp: 100,
-			specialDefense: 50,
-		},
-	});
-
-	const move = createMove({
-		type: "Normal",
-		base: 100,
-		category: "Special",
-	});
-
-	const battleNonChampion = new Battle({
-		attacker,
-		defender,
-		move,
-		isChampion: false,
-	});
-
-	const damageNonChampion = battleNonChampion.getDamage();
-
-	// With 16 rolls, KO chance should be calculated correctly
-	expect(damageNonChampion.koChance).toBeGreaterThanOrEqual(0);
-	expect(damageNonChampion.koChance).toBeLessThanOrEqual(100);
-
-	// Verify rolls array has 16 elements
-	expect(damageNonChampion.rolls).toHaveLength(16);
-});
-
-test("champion 2HKO vs 3HKO boundary test", () => {
-	// Create a scenario where champion vs non-champion affects KO chance
-	const attacker = genTestMon({
-		types: ["Normal"],
-		baseStat: {
-			specialAttack: 100,
-		},
-		effortValues: {
-			specialAttack: 252,
-		},
-	});
-
-	const defender = genTestMon({
-		types: ["Normal"],
-		stats: {
-			hp: 100,
-			specialDefense: 100,
-		},
-	});
-
-	const move = createMove({
-		type: "Normal",
-		base: 50,
-		category: "Special",
-	});
-
-	// Non-champion 16 rolls
-	const battleNonChampion = new Battle({
-		attacker,
-		defender,
-		move,
-		isChampion: false,
-	});
-
-	const damageNonChampion = battleNonChampion.getDamage();
-	const minNonChampion = Math.min(
-		...getDamangeNumberFromResult(damageNonChampion),
+	const rollsChampion = getDamangeNumberFromResult(battleChampion.getDamage());
+	const rollsNonChampion = getDamangeNumberFromResult(
+		battleNonChampion.getDamage(),
 	);
 
-	// Champion 15 rolls (excludes the lowest damage)
-	const battleChampion = new Battle({
+	expect(rollsChampion).toHaveLength(16);
+	expect(rollsNonChampion).toHaveLength(16);
+	expect(rollsChampion).toEqual(rollsNonChampion);
+});
+
+test("champion KO chance uses standard 16-roll denominator", () => {
+	const attacker = genTestMon({
+		types: ["Normal"],
+		baseStat: {
+			specialAttack: 100,
+		},
+		effortValues: {
+			specialAttack: 252,
+		},
+	});
+
+	const defender = genTestMon({
+		types: ["Normal"],
+		stats: {
+			hp: 100,
+			specialDefense: 100,
+		},
+	});
+
+	const move = createMove({
+		type: "Normal",
+		base: 95,
+		category: "Special",
+	});
+
+	const championResult = new Battle({
 		attacker,
 		defender,
 		move,
 		isChampion: true,
-	});
+	}).getDamage();
 
-	const damageChampion = battleChampion.getDamage();
-	const minChampion = Math.min(...getDamangeNumberFromResult(damageChampion));
+	const nonChampionResult = new Battle({
+		attacker,
+		defender,
+		move,
+		isChampion: false,
+	}).getDamage();
 
-	// Champion's minimum should be higher than non-champion's minimum
-	expect(minChampion).toBeGreaterThan(minNonChampion);
+	expect(championResult.rolls).toHaveLength(16);
+	expect(nonChampionResult.rolls).toHaveLength(16);
+	expect(championResult.koChance).toBe(nonChampionResult.koChance);
 });

--- a/test/damage/item.test.ts
+++ b/test/damage/item.test.ts
@@ -37,7 +37,7 @@ test("Choice Band & Choice Spec", () => {
 	const actual = battle.getDamage();
 
 	const expected = [
-		138, 139, 142, 144, 145, 147, 148, 150, 151, 153, 154, 156, 157, 159, 162,
+		136, 138, 139, 142, 144, 145, 147, 148, 150, 151, 153, 154, 156, 157, 159, 162,
 	];
 	expect(getDamangeNumberFromResult(actual)).toEqual(expected);
 	expect(actual.factors.attacker.item).toBe(true);
@@ -49,7 +49,7 @@ test("Choice Band & Choice Spec", () => {
 	battle.swapPokemons();
 	battle.move = flareBlitz;
 	const expectedFlareBlitzDmg = [
-		124, 126, 127, 129, 130, 132, 133, 135, 136, 138, 139, 141, 142, 144, 145,
+		123, 124, 126, 127, 129, 130, 132, 133, 135, 136, 138, 139, 141, 142, 144, 145,
 	];
 	const actualFlareBlitzDmg = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualFlareBlitzDmg)).toEqual(
@@ -58,7 +58,7 @@ test("Choice Band & Choice Spec", () => {
 
 	incineroar.item = "Choice Band";
 	const expectedFlareBlitzDmgWithCB = [
-		184, 187, 189, 192, 193, 196, 198, 199, 202, 204, 207, 208, 211, 213, 216,
+		183, 184, 187, 189, 192, 193, 196, 198, 199, 202, 204, 207, 208, 211, 213, 216,
 	];
 	const actualFlareBlitzDmgWithCB = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualFlareBlitzDmgWithCB)).toEqual(
@@ -95,7 +95,7 @@ test("Type enhancing", () => {
 		move: moonblast,
 	});
 	const expected = [
-		111, 112, 114, 115, 117, 118, 120, 120, 121, 123, 124, 126, 127, 129, 130,
+		109, 111, 112, 114, 115, 117, 118, 120, 120, 121, 123, 124, 126, 127, 129, 130,
 	];
 	const actual = battle.getDamage();
 
@@ -131,7 +131,7 @@ test("life orb", () => {
 		move: moonblast,
 	});
 	const expected = [
-		121, 122, 125, 125, 126, 129, 130, 130, 133, 134, 137, 137, 138, 140, 142,
+		121, 121, 122, 125, 125, 126, 129, 130, 130, 133, 134, 137, 137, 138, 140, 142,
 	];
 	const actual = battle.getDamage();
 
@@ -167,7 +167,7 @@ test("Metronome", () => {
 	});
 	// 2 times
 	const expected = [
-		194, 194, 197, 202, 202, 204, 204, 209, 211, 211, 216, 218, 218, 223, 226,
+		190, 194, 194, 197, 202, 202, 204, 204, 209, 211, 211, 216, 218, 218, 223, 226,
 	];
 	const actual = battle.getDamage();
 	expect(getDamangeNumberFromResult(actual)).toEqual(expected);
@@ -202,7 +202,7 @@ test("Assult vest", () => {
 		defender: incineroar,
 		move: moonblast,
 	});
-	const expected = [63, 63, 64, 64, 66, 66, 67, 67, 69, 69, 70, 70, 72, 72, 73];
+	const expected = [61, 63, 63, 64, 64, 66, 66, 67, 67, 69, 69, 70, 70, 72, 72, 73];
 	const actual = battle.getDamage();
 
 	expect(getDamangeNumberFromResult(actual)).toEqual(expected);
@@ -238,7 +238,7 @@ test("Psyshock on AV mon", () => {
 	});
 
 	const expected = [
-		114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
+		114, 114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
 	];
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(expected);
@@ -270,7 +270,7 @@ test("Eviolite", () => {
 		base: 95,
 		category: "Special",
 	});
-	const expected = [60, 60, 61, 61, 63, 63, 64, 64, 66, 66, 67, 67, 69, 69, 70];
+	const expected = [58, 60, 60, 61, 61, 63, 63, 64, 64, 66, 66, 67, 67, 69, 69, 70];
 	const battle = new Battle({
 		attacker: flutterMane,
 		defender: porygon2,
@@ -311,7 +311,7 @@ test("Type Halving berry", () => {
 	});
 
 	const expected = [
-		96, 97, 99, 99, 100, 102, 103, 103, 105, 106, 108, 108, 109, 111, 112,
+		94, 96, 97, 99, 99, 100, 102, 103, 103, 105, 106, 108, 108, 109, 111, 112,
 	];
 	const actual = battle.getDamage();
 

--- a/test/damage/move.test.ts
+++ b/test/damage/move.test.ts
@@ -29,7 +29,7 @@ test("freeze dry", () => {
 	});
 	const actual = getDamangeNumberFromResult(battle.getDamage());
 	const expected = [
-		228, 232, 232, 240, 240, 240, 244, 244, 252, 252, 256, 256, 264, 264, 268,
+		228, 228, 232, 232, 240, 240, 240, 244, 244, 252, 252, 256, 256, 264, 264, 268,
 	];
 	expect(actual).toEqual(expected);
 });
@@ -110,7 +110,7 @@ test("Ivy Cudgel changes type", () => {
 		defender,
 		move,
 	});
-	let actual = [20, 20, 21, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 24];
+	let actual = [20, 20, 20, 21, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 24];
 	let damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 	const ogerponWellspring = genTestMon({
@@ -124,7 +124,7 @@ test("Ivy Cudgel changes type", () => {
 	battle.setPokemon("attacker", ogerponWellspring);
 	damage = battle.getDamage();
 	actual = [
-		198, 198, 200, 204, 206, 210, 210, 212, 216, 218, 218, 222, 224, 228, 230,
+		194, 198, 198, 200, 204, 206, 210, 210, 212, 216, 218, 218, 222, 224, 228, 230,
 	];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 
@@ -138,7 +138,7 @@ test("Ivy Cudgel changes type", () => {
 	});
 	battle.setPokemon("attacker", ogerponHearthflame);
 	damage = battle.getDamage();
-	actual = [49, 49, 50, 51, 51, 52, 52, 53, 54, 54, 54, 55, 56, 57, 57];
+	actual = [48, 49, 49, 50, 51, 51, 52, 52, 53, 54, 54, 54, 55, 56, 57, 57];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 	const ogerponCornerstone = genTestMon({
 		name: "ogerpon-cornerstone-mask",
@@ -151,7 +151,7 @@ test("Ivy Cudgel changes type", () => {
 	battle.setPokemon("attacker", ogerponCornerstone);
 	damage = battle.getDamage();
 	actual = [
-		396, 396, 400, 408, 412, 420, 420, 424, 432, 436, 436, 444, 448, 456, 460,
+		388, 396, 396, 400, 408, 412, 420, 420, 424, 432, 436, 436, 444, 448, 456, 460,
 	];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 });
@@ -177,7 +177,7 @@ test("Revelation Dance changes type", () => {
 		base: 90,
 	});
 
-	const actual = [29, 30, 30, 30, 30, 30, 31, 31, 32, 32, 33, 33, 33, 33, 34];
+	const actual = [29, 29, 30, 30, 30, 30, 30, 31, 31, 32, 32, 33, 33, 33, 33, 34];
 	const battle = new Battle({
 		attacker,
 		defender,
@@ -213,7 +213,7 @@ test("Ivy Cudgel changes type", () => {
 		defender,
 		move,
 	});
-	let actual = [20, 20, 21, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 24];
+	let actual = [20, 20, 20, 21, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 24];
 	let damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 	const ogerponWellspring = genTestMon({
@@ -227,7 +227,7 @@ test("Ivy Cudgel changes type", () => {
 	battle.setPokemon("attacker", ogerponWellspring);
 	damage = battle.getDamage();
 	actual = [
-		198, 198, 200, 204, 206, 210, 210, 212, 216, 218, 218, 222, 224, 228, 230,
+		194, 198, 198, 200, 204, 206, 210, 210, 212, 216, 218, 218, 222, 224, 228, 230,
 	];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 
@@ -241,7 +241,7 @@ test("Ivy Cudgel changes type", () => {
 	});
 	battle.setPokemon("attacker", ogerponHearthflame);
 	damage = battle.getDamage();
-	actual = [49, 49, 50, 51, 51, 52, 52, 53, 54, 54, 54, 55, 56, 57, 57];
+	actual = [48, 49, 49, 50, 51, 51, 52, 52, 53, 54, 54, 54, 55, 56, 57, 57];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 	const ogerponCornerstone = genTestMon({
 		name: "ogerpon-cornerstone-mask",
@@ -254,7 +254,7 @@ test("Ivy Cudgel changes type", () => {
 	battle.setPokemon("attacker", ogerponCornerstone);
 	damage = battle.getDamage();
 	actual = [
-		396, 396, 400, 408, 412, 420, 420, 424, 432, 436, 436, 444, 448, 456, 460,
+		388, 396, 396, 400, 408, 412, 420, 420, 424, 432, 436, 436, 444, 448, 456, 460,
 	];
 	expect(getDamangeNumberFromResult(damage)).toEqual(actual);
 });
@@ -285,7 +285,7 @@ test("Tera Blast changes category", () => {
 	});
 
 	const actual = [
-		114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
+		114, 114, 116, 116, 120, 120, 120, 122, 122, 126, 126, 128, 128, 132, 132, 134,
 	];
 	const battle = new Battle({
 		attacker,
@@ -326,7 +326,7 @@ test("Tera Blast changes type", () => {
 	});
 
 	const actualBeforeTera = [
-		33, 33, 34, 34, 35, 35, 35, 36, 36, 37, 37, 37, 38, 38, 39,
+		33, 33, 33, 34, 34, 35, 35, 35, 36, 36, 37, 37, 37, 38, 38, 39,
 	];
 	const damageBeforeTera = battle.getDamage();
 	expect(getDamangeNumberFromResult(damageBeforeTera)).toEqual(
@@ -339,7 +339,7 @@ test("Tera Blast changes type", () => {
 	});
 
 	const actualAfterTera = [
-		24, 24, 25, 25, 26, 26, 26, 27, 27, 27, 27, 27, 28, 28, 29,
+		24, 24, 24, 25, 25, 26, 26, 26, 27, 27, 27, 27, 27, 28, 28, 29,
 	];
 
 	const damage = battle.getDamage();
@@ -389,7 +389,7 @@ test("Collision Course increase 33% when effective, including stellar tera", () 
 	});
 
 	const actualBeforeTera = [
-		307, 312, 315, 320, 323, 323, 328, 331, 336, 339, 344, 347, 352, 355, 360,
+		304, 307, 312, 315, 320, 323, 323, 328, 331, 336, 339, 344, 347, 352, 355, 360,
 	];
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(actualBeforeTera);
@@ -438,7 +438,7 @@ test("Hadron Engine increase 33% when effective, including stellar tera", () => 
 	});
 
 	const actualBeforeTera = [
-		336, 339, 344, 347, 352, 355, 360, 363, 368, 371, 376, 379, 384, 387, 392,
+		331, 336, 339, 344, 347, 352, 355, 360, 363, 368, 371, 376, 379, 384, 387, 392,
 	];
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(actualBeforeTera);
@@ -474,6 +474,6 @@ test("Hydro steam should have 1,5x damage in Sun", () => {
 	});
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual([
-		182, 186, 188, 192, 192, 194, 198, 198, 200, 204, 206, 206, 210, 212, 216,
+		182, 182, 186, 188, 192, 192, 194, 198, 198, 200, 204, 206, 206, 210, 212, 216,
 	]);
 });

--- a/test/damage/statStages.test.ts
+++ b/test/damage/statStages.test.ts
@@ -32,7 +32,7 @@ test("test stage changes", () => {
 	});
 	// test +c
 	const expectedWhenPlus1C = [
-		115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
+		114, 115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
 	];
 	const actualWhenPlus1C = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualWhenPlus1C)).toEqual(
@@ -42,7 +42,7 @@ test("test stage changes", () => {
 	// test -c
 	flutterMane.statStage.specialAttack = -1;
 	const expectedWhenMinus1C = [
-		52, 52, 54, 54, 54, 55, 55, 57, 57, 57, 58, 58, 60, 60, 61,
+		51, 52, 52, 54, 54, 54, 55, 55, 57, 57, 57, 58, 58, 60, 60, 61,
 	];
 	const actualWhenMinus1C = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualWhenMinus1C)).toEqual(
@@ -53,7 +53,7 @@ test("test stage changes", () => {
 	// test +d from defender
 	incineroar.statStage.specialDefense = 1;
 	const expectedWhenPlus1D = [
-		52, 52, 54, 54, 54, 55, 55, 57, 57, 57, 58, 58, 60, 60, 61,
+		51, 52, 52, 54, 54, 54, 55, 55, 57, 57, 57, 58, 58, 60, 60, 61,
 	];
 	const actualWhenPlus1D = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualWhenPlus1D)).toEqual(
@@ -63,7 +63,7 @@ test("test stage changes", () => {
 	// test d from defender
 	incineroar.statStage.specialDefense = -1;
 	const expectedWhenMinus1D = [
-		115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
+		114, 115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
 	];
 	const actualWhenMinus1D = battle.getDamage();
 	expect(getDamangeNumberFromResult(actualWhenMinus1D)).toEqual(
@@ -103,7 +103,7 @@ test("test critical hit", () => {
 		move: moonblast,
 	});
 	const actual = [
-		115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
+		114, 115, 117, 118, 120, 121, 121, 123, 124, 126, 127, 129, 130, 132, 133, 135,
 	];
 
 	let damage = battle.getDamage();
@@ -147,7 +147,7 @@ test("test sacred sword", () => {
 		move: sacredSword,
 	});
 	const actual = [
-		108, 108, 110, 112, 112, 114, 114, 116, 118, 118, 120, 122, 122, 124, 126,
+		106, 108, 108, 110, 112, 112, 114, 114, 116, 118, 118, 120, 122, 122, 124, 126,
 	];
 
 	const damage = battle.getDamage();

--- a/test/damage/terapagos.test.ts
+++ b/test/damage/terapagos.test.ts
@@ -31,7 +31,7 @@ test("terapagos stellar hit charizard", () => {
 		move,
 	});
 	const expected = [
-		164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190, 192,
+		162, 164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190, 192,
 	];
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(expected);
@@ -66,7 +66,7 @@ test("terapagos stellar hit charizard with terastorm", () => {
 		defender: charizard,
 		move,
 	});
-	const expected = [59, 60, 61, 61, 62, 62, 64, 64, 65, 66, 66, 67, 67, 68, 70];
+	const expected = [59, 59, 60, 61, 61, 62, 62, 64, 64, 65, 66, 66, 67, 67, 68, 70];
 	const damage = battle.getDamage();
 	expect(getDamangeNumberFromResult(damage)).toEqual(expected);
 });


### PR DESCRIPTION
### Motivation
- Unify damage-roll behavior so champions use the same 16-roll random distribution as non-champions instead of dropping the smallest roll (previous 15-roll special-case). 
- Ensure KO chance and damage distributions are calculated from the same denominator for champions and non-champions. 

### Description
- Replace the conditional champion roll count in `src/damage/battle.ts` by setting `dmgRollCounts = 16`, removing the special 15-roll champion behavior. 
- Update the champion test to assert champions use 16 rolls and that `koChance` matches the non-champion result. 
- Adjust expected damage arrays in multiple unit tests under `test/damage/` to reflect the restored 16-roll distribution; files updated include `ability.test.ts`, `aura.test.ts`, `basic.test.ts`, `champion.test.ts`, `item.test.ts`, `move.test.ts`, `statStages.test.ts`, and `terapagos.test.ts`. 

### Testing
- Ran the test suite with `bun test` against the `test/damage` fixtures and updated expectations; all modified tests passed. 
- Verified champion-specific assertions by running the updated `champion.test.ts` which now confirms 16 rolls and equal `koChance` for champion and non-champion scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d32060df8832f9836a9bc775e0b89)