### PR TITLE
Use rational multipliers for speed calculation and add Electro Ball threshold test

### DIFF
--- a/.changeset/ten-buckets-judge.md
+++ b/.changeset/ten-buckets-judge.md
@@ -1,0 +1,5 @@
+---
+"vgc_data_wrapper": patch
+---
+
+Fix speed-based base power calculation to avoid double-counting stat stages for Electro Ball and Gyro Ball. Add a regression test confirming Choice Scarf and +1 Speed stage match at the 1.5x Electro Ball threshold.

--- a/src/damage/basePower.ts
+++ b/src/damage/basePower.ts
@@ -54,12 +54,12 @@ export function getBasePower(
 	// electric ball
 	if (move.id === 486) {
 		const attackerSpeed = speedModifier(
-			attacker.getStat("speed"),
+			attacker.getStat("speed", false),
 			attacker.item ?? "",
 			attacker.statStage.speed,
 		);
 		const defenderSpeed = speedModifier(
-			defender.getStat("speed"),
+			defender.getStat("speed", false),
 			defender.item ?? "",
 			defender.statStage.speed,
 		);
@@ -91,12 +91,12 @@ export function getBasePower(
 	// Gyro ball
 	if (move.id === 360) {
 		const attackerSpeed = speedModifier(
-			attacker.getStat("speed"),
+			attacker.getStat("speed", false),
 			attacker.item ?? "",
 			attacker.statStage.speed,
 		);
 		const defenderSpeed = speedModifier(
-			defender.getStat("speed"),
+			defender.getStat("speed", false),
 			defender.item ?? "",
 			defender.statStage.speed,
 		);
@@ -194,26 +194,27 @@ export function getBasePower(
 }
 
 function speedModifier(baseSpeed: number, item: string, stage: number): number {
-	const stageMultiplier = getStageMultiplier(stage);
+	const { numerator: stageNumerator, denominator: stageDenominator } =
+		getStageMultiplier(stage);
 	const itemModifier =
-		// Choice Scarf
 		item === "Choice Scarf"
-			? 1.5
-			: // iron ball
-				item === "Iron Ball"
-				? 0.5
-				: 1;
-	return Math.round(
-		Math.trunc(baseSpeed * stageMultiplier * (4096 * itemModifier)) / 4096 -
-			0.001,
+			? { numerator: 3, denominator: 2 }
+			: item === "Iron Ball"
+				? { numerator: 1, denominator: 2 }
+				: { numerator: 1, denominator: 1 };
+	return Math.trunc(
+		(baseSpeed *
+			stageNumerator *
+			itemModifier.numerator) /
+			(stageDenominator * itemModifier.denominator),
 	);
 }
 
 function getStageMultiplier(stage: number) {
 	if (stage > 0) {
-		return (2 + stage) / 2;
+		return { numerator: 2 + stage, denominator: 2 };
 	}
-	return 2 / (2 - stage);
+	return { numerator: 2, denominator: 2 - stage };
 }
 
 function weightModifier(base: number, ability?: Ability) {

--- a/test/damage/internal/base.test.ts
+++ b/test/damage/internal/base.test.ts
@@ -190,6 +190,40 @@ test("correctly calculate base power for speed related moves", () => {
 	expect(basePowerGyroBall.operator).toBe(100);
 });
 
+
+test("electro ball: Choice Scarf and +1 speed stage match at the 1.5x threshold", () => {
+	const defender = genTestMon({
+		stats: {
+			speed: 100,
+		},
+	});
+	const electroBall = createMove({
+		id: 486,
+	});
+
+	const scarfAttacker = genTestMon({
+		stats: {
+			speed: 100,
+		},
+		item: "Choice Scarf",
+	});
+	const plusOneAttacker = genTestMon({
+		stats: {
+			speed: 100,
+		},
+		statStage: {
+			speed: 1,
+		},
+	});
+
+	const scarfPower = getBasePower(scarfAttacker, defender, electroBall);
+	const plusOnePower = getBasePower(plusOneAttacker, defender, electroBall);
+
+	expect(scarfPower.operator).toBe(60);
+	expect(plusOnePower.operator).toBe(60);
+	expect(scarfPower.operator).toBe(plusOnePower.operator);
+});
+
 test("correctly calculate base power for Grass knot and Low kick", () => {
 	const testPokemon = genTestMon();
 	const lowKick = createMove({


### PR DESCRIPTION
### Motivation

- Fix precision and consistency in speed-based base power calculations so item effects like `Choice Scarf` and stage boosts produce the expected thresholds. 
- Ensure `Electro Ball` treats a 1.5x speed advantage from item vs stage identically.

### Description

- Replace floating-point stage multiplier with a rational representation by changing `getStageMultiplier` to return `{ numerator, denominator }` and propagate that into `speedModifier` to compute speed as an exact truncated integer. 
- Convert item speed modifiers in `speedModifier` into matching rational `{ numerator, denominator }` values and compute the resulting speed with integer truncation. 
- Update callers of `getStat` for speed-related moves to use `getStat("speed", false)` when computing base speed for move base power formulas. 
- Add a unit test `electro ball: Choice Scarf and +1 speed stage match at the 1.5x threshold` to assert that `Choice Scarf` and `+1` speed stage both yield the same `Electro Ball` base power outcome.

### Testing

- Ran the modified unit tests in `test/damage/internal/base.test.ts` including the new `electro ball` test, and they passed. 
- Existing base power tests for `Gyro Ball`, `Grass Knot`, and `Low Kick` were executed and continued to pass. 
- No automated test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6b910064832f87e6f0cc1bc5314c)