### PR TITLE
Follow-up: fix Foul Play min-attack requirement EV search in PR #160

### DIFF
--- a/src/damage/requirement.ts
+++ b/src/damage/requirement.ts
@@ -60,7 +60,6 @@ const maxTotal = (ruleset: StatRuleset) =>
 const usesPhysicalDefense = (move: Move) =>
 	move.category === "Physical" || move.id === 473 || move.id === 540; // Psyshock & Psystrike
 const usesDefenseAsAttack = (move: Move) => move.id === 776; // Body Press
-const usesDefenderAttack = (move: Move) => move.id === 492; // Foul Play
 const getOffensiveEvKey = (
 	move: Move,
 ): "attack" | "specialAttack" | "defense" =>
@@ -185,30 +184,6 @@ export function getMinAtkRequirement({
 	const atkKey = getOffensiveEvKey(move);
 	const max = maxPerStat(ruleset);
 	const totalMax = maxTotal(ruleset);
-	if (usesDefenderAttack(move)) {
-		const damage = new Battle({
-			attacker,
-			defender,
-			move,
-			field,
-		}).getDamage();
-		if (!meetsTarget(damage, target, "atk", defender.getStat("hp"))) {
-			return {
-				satisfied: false,
-				target,
-				reason: "No valid investment satisfies the target",
-				statRuleset: ruleset,
-			};
-		}
-		return {
-			satisfied: true,
-			target,
-			investment: { attack: 0 },
-			finalStats: { attack: attacker.getStat("attack") },
-			damage,
-			statRuleset: ruleset,
-		};
-	}
 	const baseTotal =
 		Object.values(attacker.effortValues).reduce(
 			(sum, value) => sum + value,


### PR DESCRIPTION
### Motivation
- Fix a bug where `getMinAtkRequirement` short-circuited for Foul Play by checking damage once and returning `investment: { attack: 0 }`, which produced incorrect results when damage modifiers depend on attacker stats (e.g., `Quark Drive` / `Protosynthesis`).
- Ensure the offensive EV search considers attacker EV variations for moves that reference defender Attack so satisfiable targets are not incorrectly marked impossible.

### Description
- Removed the Foul Play-specific early-return fast path from `getMinAtkRequirement` in `src/damage/requirement.ts` so Foul Play now enters the same attacker EV sweep as other moves. 
- The attacker EV sweep now constructs `Pokemon` instances with candidate EVs and runs `Battle.getDamage()` for each candidate, returning the minimal satisfying investment when found.

### Testing
- Ran the focused test `bun test test/damage/requirements.test.ts -t "Foul Play"`, which passed. 
- A full run of `test/damage/requirements.test.ts` during troubleshooting previously showed a failing expectation caused by an interim test edit, and the final focused test run confirmed the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126a271920832fb25e48e3c932ee1d)