### PR TITLE
Add champions-mode real-world tuned requirement tests

### DIFF
--- a/test/damage/requirements.test.ts
+++ b/test/damage/requirements.test.ts
@@ -606,6 +606,86 @@ test("mainSeries EV-cap boundaries include unrelated EVs", () => {
 	}
 });
 
+test("champions real-world tuned cases from manual verification", () => {
+	const championsAtk = assertAtkRequirement({
+		attacker: genTestMon({
+			statRuleset: "champions",
+			level: 50,
+			types: ["Electric"],
+			baseStat: {
+				hp: 80,
+				attack: 70,
+				defense: 70,
+				specialAttack: 125,
+				specialDefense: 80,
+				speed: 110,
+			},
+			nature: { plus: "specialAttack", minus: "attack" },
+		}),
+		defender: genTestMon({
+			statRuleset: "champions",
+			level: 50,
+			types: ["Water"],
+			baseStat: {
+				hp: 100,
+				attack: 70,
+				defense: 90,
+				specialAttack: 70,
+				specialDefense: 95,
+				speed: 60,
+			},
+			nature: { plus: "specialDefense", minus: "attack" },
+		}),
+		move: createMove({
+			type: "Electric",
+			base: 55,
+			category: "Special",
+		}),
+		target: { type: "guaranteed-2hit" },
+	});
+	expect(championsAtk?.axis).toBe("specialAttack");
+	expect(championsAtk?.ev).toBe(17);
+
+	const championsDef = assertDefRequirement({
+		attacker: genTestMon({
+			statRuleset: "champions",
+			level: 50,
+			types: ["Fire"],
+			baseStat: {
+				hp: 84,
+				attack: 78,
+				defense: 78,
+				specialAttack: 109,
+				specialDefense: 85,
+				speed: 100,
+			},
+		}),
+		defender: genTestMon({
+			statRuleset: "champions",
+			level: 50,
+			types: ["Steel", "Fairy"],
+			baseStat: {
+				hp: 95,
+				attack: 80,
+				defense: 115,
+				specialAttack: 95,
+				specialDefense: 110,
+				speed: 50,
+			},
+		}),
+		move: createMove({
+			type: "Fire",
+			base: 90,
+			category: "Special",
+		}),
+		field: { weather: "Sun" },
+		target: { type: "chance", value: 75 },
+	});
+	expect(championsDef?.defAxis).toBe("specialDefense");
+	expect(championsDef?.hp).toBe(1);
+	expect(championsDef?.dv).toBe(1);
+});
+
 test("boundary target semantics stay stable", () => {
 	expect(
 		meetsTarget("atk", 100, { type: "chance", value: 100 }, 100, [


### PR DESCRIPTION
### Motivation

- Add regression tests that capture hand-verified behavior for the `champions` stat ruleset to ensure requirement calculations remain correct.

### Description

- Add a new test `champions real-world tuned cases from manual verification` in `test/damage/requirements.test.ts` that validates two real-world scenarios for attack and defense requirement calculations.  
- The test uses `genTestMon` to construct attacker/defender Pokémon under the `champions` ruleset and `createMove` to configure moves, asserting an attack requirement (`axis` = `specialAttack`, `ev` = 17) for a `guaranteed-2hit` target and a defense requirement (`defAxis` = `specialDefense`, `hp` = 1, `dv` = 1) for a `chance` target with `weather: "Sun"`.

### Testing

- Ran the test suite with `yarn test` and the new test passed along with the existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13746ac740832fa481ba42a5fde6a1)