### PR TITLE
Add EV & nature optimizer for Champions ruleset and related tests

### DIFF
--- a/.changeset/optimize-ev-nature-docs.md
+++ b/.changeset/optimize-ev-nature-docs.md
@@ -1,0 +1,5 @@
+---
+"vgc_data_wrapper": patch
+---
+
+Add documentation for `optimizeEVAndNature` in the README and align optimizer-focused Pokemon tests to champions ruleset scenarios.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,44 @@ const damageResult = battle.getDamage();
 
 * Other properties can be updated directly without using specific method for now. 
 
+##### EV/Nature optimizer: `optimizeEVAndNature`
+
+Use this helper when you want to keep a Pokémon's final stats exactly the same while reducing EV cost (and optionally changing nature).
+
+```ts
+import { Pokemon, optimizeEVAndNature } from "vgc_data_wrapper";
+
+const pokemon = new Pokemon({
+	statRuleset: "champions", // also supports "mainSeries"
+	baseStat: {
+		hp: 95,
+		attack: 115,
+		defense: 90,
+		specialAttack: 80,
+		specialDefense: 90,
+		speed: 60,
+	},
+	effortValues: {
+		defense: 11,
+	},
+});
+
+const result = optimizeEVAndNature(pokemon);
+
+if (result.foundImprovement) {
+	console.log(result.savedEffortValues); // EVs saved
+	console.log(result.optimized.effortValues);
+	console.log(result.optimized.nature);
+}
+```
+
+Notes:
+- Preserves all six final stats exactly.
+- Optimizes EV + nature only (IVs are not optimized).
+- Respects the Pokémon's active `statRuleset` (`champions` or `mainSeries`).
+- Returns deterministic output via fixed tie-break rules.
+- Throws if manual `stats` are inconsistent with derived stats.
+
 ##### Stat & StatStages
 ```
 const statProps = [

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ const pokemon = new Pokemon({
 	},
 });
 
-const result = optimizeEVAndNature(pokemon);
+const result = optimizeEVAndNature(pokemon, {
+	statAcceptReduction: ["specialAttack"], // optional, non-HP only
+});
 
 if (result.foundImprovement) {
 	console.log(result.savedEffortValues); // EVs saved
@@ -123,10 +125,12 @@ if (result.foundImprovement) {
 
 Notes:
 - Preserves all six final stats exactly.
+- If `statAcceptReduction` is provided, listed non-HP stats may be optimized to lower final values (`<=` original).
 - Optimizes EV + nature only (IVs are not optimized).
 - Respects the Pokémon's active `statRuleset` (`champions` or `mainSeries`).
 - Returns deterministic output via fixed tie-break rules.
 - Throws if manual `stats` are inconsistent with derived stats.
+- Throws if `statAcceptReduction` includes `hp`.
 
 ##### Stat & StatStages
 ```

--- a/src/pokemon/effortValue.ts
+++ b/src/pokemon/effortValue.ts
@@ -1,6 +1,6 @@
 import type { StatRuleset } from "./base";
 
-const getMaxEvPerStat = (ruleset: StatRuleset) =>
+export const getMaxEvPerStat = (ruleset: StatRuleset) =>
 	ruleset === "mainSeries" ? 252 : 32;
 
 export const getMaxTotalEvs = (ruleset: StatRuleset) =>

--- a/src/pokemon/index.ts
+++ b/src/pokemon/index.ts
@@ -1,4 +1,5 @@
 export { Pokemon } from "./base";
+export { optimizeEVAndNature } from "./optimizeEVAndNature";
 export {
 	getPasteFromPokemons,
 	getPokemonFromPaste,

--- a/src/pokemon/optimizeEVAndNature.ts
+++ b/src/pokemon/optimizeEVAndNature.ts
@@ -162,6 +162,7 @@ function clonePokemonLike(
 	effortValues: Stat,
 ): Pokemon {
 	return new Pokemon({
+		id: pokemon.id,
 		level: pokemon.level,
 		baseStat: cloneStats(pokemon.baseStat),
 		individualValues: cloneStats(pokemon.individualValues),

--- a/src/pokemon/optimizeEVAndNature.ts
+++ b/src/pokemon/optimizeEVAndNature.ts
@@ -150,7 +150,7 @@ function getAllowedNatures(originalNature: Nature): Nature[] {
 function getDerivedStats(pokemon: Pokemon): Stat {
 	const clone = clonePokemonLike(
 		pokemon,
-		cloneNature(pokemon.nature),
+		pokemon.nature,
 		cloneStats(pokemon.effortValues),
 	);
 	return clone.getStats(false);

--- a/src/pokemon/optimizeEVAndNature.ts
+++ b/src/pokemon/optimizeEVAndNature.ts
@@ -6,6 +6,10 @@ type Nature = Pokemon["nature"];
 type StatKey = keyof Stat;
 type NonHpStatKey = Exclude<StatKey, "hp">;
 
+type OptimizeEVAndNatureOptions = {
+	statAcceptReduction?: StatKey[];
+};
+
 type OptimizeEVAndNatureSnapshot = {
 	effortValues: Stat;
 	nature: Nature;
@@ -53,7 +57,9 @@ const NATURES: Nature[] = [
 
 export function optimizeEVAndNature(
 	pokemon: Pokemon,
+	options?: OptimizeEVAndNatureOptions,
 ): OptimizeEVAndNatureResult {
+	const reducibleStats = getReducibleStats(options);
 	const originalStats = pokemon.getStats(false);
 	const derivedStats = getDerivedStats(pokemon);
 	if (!statsEqual(originalStats, derivedStats)) {
@@ -70,9 +76,15 @@ export function optimizeEVAndNature(
 		totalEffortValues: originalTotal,
 	};
 
-	const best = NATURES.reduce(
+	const targetNatures = getAllowedNatures(originalNature);
+	const best = targetNatures.reduce(
 		(currentBest, nature) => {
-			const candidate = buildCandidateEvs(pokemon, originalStats, nature);
+			const candidate = buildCandidateEvs(
+				pokemon,
+				originalStats,
+				nature,
+				reducibleStats,
+			);
 			if (!candidate) return currentBest;
 
 			if (
@@ -87,35 +99,52 @@ export function optimizeEVAndNature(
 			effortValues: Stat;
 			nature: Nature;
 			totalEffortValues: number;
+			stats: Stat;
 		},
 	);
 
-	const optimized = best ?? {
-		effortValues: originalEvs,
-		nature: originalNature,
-		totalEffortValues: originalTotal,
-	};
-
-	const savedEffortValues = originalTotal - optimized.totalEffortValues;
-	const optimizedSnapshot = {
-		effortValues: optimized.effortValues,
-		nature: optimized.nature,
-		stats: cloneStats(originalStats),
-		totalEffortValues: optimized.totalEffortValues,
-	};
-
-	if (savedEffortValues > 0) {
+	if (!best) {
 		return {
-			original,
-			optimized: optimizedSnapshot,
-			savedEffortValues,
-			foundImprovement: true,
+			foundImprovement: false,
+		};
+	}
+
+	const savedEffortValues = originalTotal - best.totalEffortValues;
+	if (savedEffortValues <= 0) {
+		return {
+			foundImprovement: false,
 		};
 	}
 
 	return {
-		foundImprovement: false,
+		original,
+		optimized: {
+			effortValues: best.effortValues,
+			nature: best.nature,
+			stats: best.stats,
+			totalEffortValues: best.totalEffortValues,
+		},
+		savedEffortValues,
+		foundImprovement: true,
 	};
+}
+
+function getReducibleStats(options?: OptimizeEVAndNatureOptions): Set<StatKey> {
+	const reducibleStats = new Set<StatKey>();
+	for (const key of options?.statAcceptReduction ?? []) {
+		if (key === "hp") {
+			throw new Error("HP reduction is not supported");
+		}
+		reducibleStats.add(key);
+	}
+	return reducibleStats;
+}
+
+function getAllowedNatures(originalNature: Nature): Nature[] {
+	if (!originalNature.minus) {
+		return NATURES;
+	}
+	return NATURES.filter((nature) => nature.minus === originalNature.minus);
 }
 
 function getDerivedStats(pokemon: Pokemon): Stat {
@@ -146,9 +175,10 @@ function buildCandidateEvs(
 	pokemon: Pokemon,
 	targetStats: Stat,
 	nature: Nature,
+	reducibleStats: Set<StatKey>,
 ) {
 	const maxPerStat = getMaxEvPerStat(pokemon.statRuleset);
-	const effortValues = {
+	const effortValues: Stat = {
 		hp: 0,
 		attack: 0,
 		defense: 0,
@@ -164,6 +194,7 @@ function buildCandidateEvs(
 			targetStats[key],
 			nature,
 			maxPerStat,
+			reducibleStats.has(key),
 		);
 		if (ev === null) return null;
 		effortValues[key] = ev;
@@ -174,7 +205,22 @@ function buildCandidateEvs(
 		return null;
 	}
 
-	return { effortValues, nature: cloneNature(nature), totalEffortValues };
+	const stats = clonePokemonLike(pokemon, nature, effortValues).getStats(false);
+	for (const key of STAT_KEYS) {
+		if (!reducibleStats.has(key) && stats[key] !== targetStats[key]) {
+			return null;
+		}
+		if (reducibleStats.has(key) && stats[key] > targetStats[key]) {
+			return null;
+		}
+	}
+
+	return {
+		effortValues,
+		nature: cloneNature(nature),
+		totalEffortValues,
+		stats,
+	};
 }
 
 function findMinEvForStat(
@@ -183,9 +229,10 @@ function findMinEvForStat(
 	targetStat: number,
 	nature: Nature,
 	maxPerStat: number,
+	allowReduction: boolean,
 ): number | null {
 	for (let ev = 0; ev <= maxPerStat; ev++) {
-		const effortValues = {
+		const effortValues: Stat = {
 			hp: 0,
 			attack: 0,
 			defense: 0,
@@ -198,6 +245,10 @@ function findMinEvForStat(
 			statKey,
 			false,
 		);
+		if (allowReduction) {
+			if (value <= targetStat) return ev;
+			continue;
+		}
 		if (value === targetStat) return ev;
 		if (value > targetStat) return null;
 	}

--- a/src/pokemon/optimizeEVAndNature.ts
+++ b/src/pokemon/optimizeEVAndNature.ts
@@ -1,0 +1,256 @@
+import type { Stat } from "../damage/config";
+import { Pokemon } from "./base";
+import { getMaxEvPerStat, getMaxTotalEvs } from "./effortValue";
+
+type Nature = Pokemon["nature"];
+type StatKey = keyof Stat;
+type NonHpStatKey = Exclude<StatKey, "hp">;
+
+type OptimizeEVAndNatureSnapshot = {
+	effortValues: Stat;
+	nature: Nature;
+	stats: Stat;
+	totalEffortValues: number;
+};
+
+type OptimizeEVAndNatureResult =
+	| {
+			original: OptimizeEVAndNatureSnapshot;
+			optimized: OptimizeEVAndNatureSnapshot;
+			savedEffortValues: number;
+			foundImprovement: true;
+	  }
+	| {
+			foundImprovement: false;
+	  };
+
+const STAT_KEYS: StatKey[] = [
+	"hp",
+	"attack",
+	"defense",
+	"specialAttack",
+	"specialDefense",
+	"speed",
+];
+
+const NON_HP_STAT_KEYS: NonHpStatKey[] = [
+	"attack",
+	"defense",
+	"specialAttack",
+	"specialDefense",
+	"speed",
+];
+
+const NATURES: Nature[] = [
+	{},
+	...NON_HP_STAT_KEYS.flatMap((plus) =>
+		NON_HP_STAT_KEYS.filter((minus) => minus !== plus).map((minus) => ({
+			plus,
+			minus,
+		})),
+	),
+];
+
+export function optimizeEVAndNature(
+	pokemon: Pokemon,
+): OptimizeEVAndNatureResult {
+	const originalStats = pokemon.getStats(false);
+	const derivedStats = getDerivedStats(pokemon);
+	if (!statsEqual(originalStats, derivedStats)) {
+		throw new Error("Provided manual stats are inconsistent");
+	}
+
+	const originalNature = cloneNature(pokemon.nature);
+	const originalEvs = cloneStats(pokemon.effortValues);
+	const originalTotal = getTotalEvs(originalEvs);
+	const original = {
+		effortValues: originalEvs,
+		nature: originalNature,
+		stats: cloneStats(originalStats),
+		totalEffortValues: originalTotal,
+	};
+
+	const best = NATURES.reduce(
+		(currentBest, nature) => {
+			const candidate = buildCandidateEvs(pokemon, originalStats, nature);
+			if (!candidate) return currentBest;
+
+			if (
+				!currentBest ||
+				isBetter(candidate, currentBest, originalEvs, originalNature)
+			) {
+				return candidate;
+			}
+			return currentBest;
+		},
+		null as null | {
+			effortValues: Stat;
+			nature: Nature;
+			totalEffortValues: number;
+		},
+	);
+
+	const optimized = best ?? {
+		effortValues: originalEvs,
+		nature: originalNature,
+		totalEffortValues: originalTotal,
+	};
+
+	const savedEffortValues = originalTotal - optimized.totalEffortValues;
+	const optimizedSnapshot = {
+		effortValues: optimized.effortValues,
+		nature: optimized.nature,
+		stats: cloneStats(originalStats),
+		totalEffortValues: optimized.totalEffortValues,
+	};
+
+	if (savedEffortValues > 0) {
+		return {
+			original,
+			optimized: optimizedSnapshot,
+			savedEffortValues,
+			foundImprovement: true,
+		};
+	}
+
+	return {
+		foundImprovement: false,
+	};
+}
+
+function getDerivedStats(pokemon: Pokemon): Stat {
+	const clone = clonePokemonLike(
+		pokemon,
+		undefined,
+		cloneStats(pokemon.effortValues),
+	);
+	return clone.getStats(false);
+}
+
+function clonePokemonLike(
+	pokemon: Pokemon,
+	nature: Nature | undefined,
+	effortValues: Stat,
+): Pokemon {
+	return new Pokemon({
+		level: pokemon.level,
+		baseStat: cloneStats(pokemon.baseStat),
+		individualValues: cloneStats(pokemon.individualValues),
+		effortValues,
+		statRuleset: pokemon.statRuleset,
+		nature: nature ?? cloneNature(pokemon.nature),
+	});
+}
+
+function buildCandidateEvs(
+	pokemon: Pokemon,
+	targetStats: Stat,
+	nature: Nature,
+) {
+	const maxPerStat = getMaxEvPerStat(pokemon.statRuleset);
+	const effortValues = {
+		hp: 0,
+		attack: 0,
+		defense: 0,
+		specialAttack: 0,
+		specialDefense: 0,
+		speed: 0,
+	};
+
+	for (const key of STAT_KEYS) {
+		const ev = findMinEvForStat(
+			pokemon,
+			key,
+			targetStats[key],
+			nature,
+			maxPerStat,
+		);
+		if (ev === null) return null;
+		effortValues[key] = ev;
+	}
+
+	const totalEffortValues = getTotalEvs(effortValues);
+	if (totalEffortValues > getMaxTotalEvs(pokemon.statRuleset)) {
+		return null;
+	}
+
+	return { effortValues, nature: cloneNature(nature), totalEffortValues };
+}
+
+function findMinEvForStat(
+	pokemon: Pokemon,
+	statKey: StatKey,
+	targetStat: number,
+	nature: Nature,
+	maxPerStat: number,
+): number | null {
+	for (let ev = 0; ev <= maxPerStat; ev++) {
+		const effortValues = {
+			hp: 0,
+			attack: 0,
+			defense: 0,
+			specialAttack: 0,
+			specialDefense: 0,
+			speed: 0,
+		};
+		effortValues[statKey] = ev;
+		const value = clonePokemonLike(pokemon, nature, effortValues).getStat(
+			statKey,
+			false,
+		);
+		if (value === targetStat) return ev;
+		if (value > targetStat) return null;
+	}
+	return null;
+}
+
+function isBetter(
+	candidate: { effortValues: Stat; nature: Nature; totalEffortValues: number },
+	best: { effortValues: Stat; nature: Nature; totalEffortValues: number },
+	originalEvs: Stat,
+	originalNature: Nature,
+) {
+	if (candidate.totalEffortValues !== best.totalEffortValues) {
+		return candidate.totalEffortValues < best.totalEffortValues;
+	}
+	const candidateNatureMatch = natureEqual(candidate.nature, originalNature);
+	const bestNatureMatch = natureEqual(best.nature, originalNature);
+	if (candidateNatureMatch !== bestNatureMatch) return candidateNatureMatch;
+
+	const candidateDistance = getDistance(candidate.effortValues, originalEvs);
+	const bestDistance = getDistance(best.effortValues, originalEvs);
+	if (candidateDistance !== bestDistance) {
+		return candidateDistance < bestDistance;
+	}
+
+	for (const key of STAT_KEYS) {
+		if (candidate.effortValues[key] !== best.effortValues[key]) {
+			return candidate.effortValues[key] < best.effortValues[key];
+		}
+	}
+	return false;
+}
+
+function getDistance(a: Stat, b: Stat) {
+	return STAT_KEYS.reduce((total, key) => total + Math.abs(a[key] - b[key]), 0);
+}
+
+function getTotalEvs(effortValues: Stat) {
+	return Object.values(effortValues).reduce((sum, value) => sum + value, 0);
+}
+
+function statsEqual(a: Stat, b: Stat) {
+	return STAT_KEYS.every((key) => a[key] === b[key]);
+}
+
+function natureEqual(a: Nature, b: Nature) {
+	return a.plus === b.plus && a.minus === b.minus;
+}
+
+function cloneStats(stat: Stat): Stat {
+	return { ...stat };
+}
+
+function cloneNature(nature: Nature): Nature {
+	return { ...nature };
+}

--- a/src/pokemon/optimizeEVAndNature.ts
+++ b/src/pokemon/optimizeEVAndNature.ts
@@ -150,7 +150,7 @@ function getAllowedNatures(originalNature: Nature): Nature[] {
 function getDerivedStats(pokemon: Pokemon): Stat {
 	const clone = clonePokemonLike(
 		pokemon,
-		undefined,
+		cloneNature(pokemon.nature),
 		cloneStats(pokemon.effortValues),
 	);
 	return clone.getStats(false);
@@ -158,7 +158,7 @@ function getDerivedStats(pokemon: Pokemon): Stat {
 
 function clonePokemonLike(
 	pokemon: Pokemon,
-	nature: Nature | undefined,
+	nature: Nature,
 	effortValues: Stat,
 ): Pokemon {
 	return new Pokemon({
@@ -168,7 +168,7 @@ function clonePokemonLike(
 		individualValues: cloneStats(pokemon.individualValues),
 		effortValues,
 		statRuleset: pokemon.statRuleset,
-		nature: nature ?? cloneNature(pokemon.nature),
+		nature: cloneNature(nature),
 	});
 }
 

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -162,6 +162,10 @@ test("champions optimizer should find lower-EV equivalent spreads", () => {
 	}
 
 	expect(result.optimized.effortValues.speed).toBe(9);
+	expect(result.optimized.nature).toEqual({
+		plus: "defense",
+		minus: "speed",
+	});
 	expect(result.savedEffortValues).toBe(2);
 	expect(result.original.stats).toEqual(result.optimized.stats);
 });

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -356,3 +356,39 @@ test("optimizer may choose minus nature when original nature has no minus", () =
 	expect(result.original.nature.minus).toBeUndefined();
 	expect(result.optimized.nature.minus).toBe("specialAttack");
 });
+
+test("optimizer should improve only when statAcceptReduction is provided", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 10,
+			specialAttack: 10,
+			speed: 11,
+		},
+		nature: {
+			plus: "attack",
+		},
+	});
+
+	const withoutReduction = optimizeEVAndNature(pokemon);
+	expect(withoutReduction.foundImprovement).toBe(false);
+
+	const withReduction = optimizeEVAndNature(pokemon, {
+		statAcceptReduction: ["specialAttack"],
+	});
+	expect(withReduction.foundImprovement).toBe(true);
+	if (!withReduction.foundImprovement) {
+		throw new Error("Expected improvement");
+	}
+	expect(withReduction.optimized.stats.specialAttack).toBeLessThanOrEqual(
+		pokemon.getStats(false).specialAttack,
+	);
+});

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -248,6 +248,111 @@ test("optimizer should throw on inconsistent manual stats", () => {
 	);
 });
 
+test("optimizer should normalize wasted EVs in mainSeries", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "mainSeries",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+		},
+		effortValues: {
+			attack: 6,
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon);
+	expect(result.foundImprovement).toBe(true);
+	if (!result.foundImprovement) {
+		throw new Error("Expected improvement");
+	}
+	expect(result.optimized.effortValues.attack).toBe(4);
+	expect(result.savedEffortValues).toBe(2);
+	expect(result.original.stats).toEqual(result.optimized.stats);
+});
+
+test("optimizer should preserve mainSeries breakpoint EVs", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "mainSeries",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+		},
+		effortValues: {
+			attack: 252,
+		},
+		nature: {
+			plus: "attack",
+			minus: "speed",
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon);
+	expect(result.foundImprovement).toBe(false);
+});
+
+test("optimizer should accept consistent manual stats", () => {
+	const derivedPokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		individualValues: {
+			hp: 31,
+			attack: 31,
+			defense: 31,
+			specialAttack: 31,
+			specialDefense: 31,
+			speed: 31,
+		},
+		effortValues: {
+			attack: 4,
+			defense: 8,
+			speed: 10,
+		},
+		nature: {
+			plus: "attack",
+			minus: "specialAttack",
+		},
+	});
+
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		individualValues: {
+			hp: 31,
+			attack: 31,
+			defense: 31,
+			specialAttack: 31,
+			specialDefense: 31,
+			speed: 31,
+		},
+		effortValues: {
+			attack: 4,
+			defense: 8,
+			speed: 10,
+		},
+		nature: {
+			plus: "attack",
+			minus: "specialAttack",
+		},
+		stats: derivedPokemon.getStats(false),
+	});
+
+	expect(() => optimizeEVAndNature(pokemon)).not.toThrow();
+});
+
 test("optimizer should accept derived stats for Shedinja", () => {
 	const pokemon = new Pokemon({
 		id: 292,

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -186,7 +186,7 @@ test("optimizer should preserve valid breakpoint EVs", () => {
 		},
 		nature: {
 			plus: "attack",
-			minus: "specialAttack",
+			minus: "speed",
 		},
 	});
 
@@ -211,7 +211,7 @@ test("optimizer should have deterministic tie-breaks", () => {
 		},
 		nature: {
 			plus: "attack",
-			minus: "specialAttack",
+			minus: "speed",
 		},
 	});
 
@@ -295,7 +295,7 @@ test("optimizer should allow lowered non-HP stats when statAcceptReduction is se
 		},
 		nature: {
 			plus: "attack",
-			minus: "specialAttack",
+			minus: "speed",
 		},
 	});
 
@@ -306,6 +306,7 @@ test("optimizer should allow lowered non-HP stats when statAcceptReduction is se
 	if (!result.foundImprovement) {
 		throw new Error("Expected improvement");
 	}
+	expect(result.optimized.nature.minus).toBe("speed");
 	expect(result.optimized.stats.specialAttack).toBeLessThanOrEqual(
 		result.original.stats.specialAttack,
 	);

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -324,3 +324,35 @@ test("optimizer should reject hp in statAcceptReduction", () => {
 		}),
 	).toThrow("HP reduction is not supported");
 });
+
+test("optimizer may choose minus nature when original nature has no minus", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 10,
+			specialAttack: 10,
+			speed: 11,
+		},
+		nature: {
+			plus: "attack",
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon, {
+		statAcceptReduction: ["specialAttack"],
+	});
+	expect(result.foundImprovement).toBe(true);
+	if (!result.foundImprovement) {
+		throw new Error("Expected improvement");
+	}
+	expect(result.original.nature.minus).toBeUndefined();
+	expect(result.optimized.nature.minus).toBe("specialAttack");
+});

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -357,7 +357,7 @@ test("optimizer may choose minus nature when original nature has no minus", () =
 	expect(result.optimized.nature.minus).toBe("specialAttack");
 });
 
-test("optimizer should improve only when statAcceptReduction is provided", () => {
+test("optimizer should find larger improvement when statAcceptReduction is provided", () => {
 	const pokemon = new Pokemon({
 		statRuleset: "champions",
 		baseStat: {
@@ -369,17 +369,16 @@ test("optimizer should improve only when statAcceptReduction is provided", () =>
 			speed: 60,
 		},
 		effortValues: {
-			attack: 10,
+			defense: 11,
 			specialAttack: 10,
-			speed: 11,
-		},
-		nature: {
-			plus: "attack",
 		},
 	});
 
 	const withoutReduction = optimizeEVAndNature(pokemon);
-	expect(withoutReduction.foundImprovement).toBe(false);
+	expect(withoutReduction.foundImprovement).toBe(true);
+	if (!withoutReduction.foundImprovement) {
+		throw new Error("Expected baseline improvement");
+	}
 
 	const withReduction = optimizeEVAndNature(pokemon, {
 		statAcceptReduction: ["specialAttack"],
@@ -388,7 +387,10 @@ test("optimizer should improve only when statAcceptReduction is provided", () =>
 	if (!withReduction.foundImprovement) {
 		throw new Error("Expected improvement");
 	}
+	expect(withReduction.savedEffortValues).toBeGreaterThan(
+		withoutReduction.savedEffortValues,
+	);
 	expect(withReduction.optimized.stats.specialAttack).toBeLessThanOrEqual(
-		pokemon.getStats(false).specialAttack,
+		withoutReduction.optimized.stats.specialAttack,
 	);
 });

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -247,3 +247,79 @@ test("optimizer should throw on inconsistent manual stats", () => {
 		"Provided manual stats are inconsistent",
 	);
 });
+
+test("optimizer should preserve minus target when input nature has minus", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 10,
+			defense: 11,
+		},
+		nature: {
+			minus: "specialAttack",
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon, {
+		statAcceptReduction: ["specialAttack"],
+	});
+
+	if (result.foundImprovement) {
+		expect(result.optimized.nature.minus).toBe("specialAttack");
+	}
+});
+
+test("optimizer should allow lowered non-HP stats when statAcceptReduction is set", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 10,
+			specialAttack: 10,
+			speed: 11,
+		},
+		nature: {
+			plus: "attack",
+			minus: "specialAttack",
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon, {
+		statAcceptReduction: ["specialAttack"],
+	});
+	expect(result.foundImprovement).toBe(true);
+	if (!result.foundImprovement) {
+		throw new Error("Expected improvement");
+	}
+	expect(result.optimized.stats.specialAttack).toBeLessThanOrEqual(
+		result.original.stats.specialAttack,
+	);
+	expect(result.optimized.stats.attack).toBe(result.original.stats.attack);
+	expect(result.optimized.stats.speed).toBe(result.original.stats.speed);
+});
+
+test("optimizer should reject hp in statAcceptReduction", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+	});
+	expect(() =>
+		optimizeEVAndNature(pokemon, {
+			statAcceptReduction: ["hp"],
+		}),
+	).toThrow("HP reduction is not supported");
+});

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -248,6 +248,36 @@ test("optimizer should throw on inconsistent manual stats", () => {
 	);
 });
 
+test("optimizer should accept derived stats for Shedinja", () => {
+	const pokemon = new Pokemon({
+		id: 292,
+		statRuleset: "champions",
+		baseStat: {
+			hp: 1,
+			attack: 90,
+			defense: 45,
+			specialAttack: 30,
+			specialDefense: 30,
+			speed: 40,
+		},
+		effortValues: {
+			hp: 32,
+			attack: 32,
+			speed: 2,
+		},
+		individualValues: {
+			hp: 31,
+			attack: 31,
+			defense: 31,
+			specialAttack: 31,
+			specialDefense: 31,
+			speed: 31,
+		},
+	});
+
+	expect(() => optimizeEVAndNature(pokemon)).not.toThrow();
+});
+
 test("optimizer should preserve minus target when input nature has minus", () => {
 	const pokemon = new Pokemon({
 		statRuleset: "champions",

--- a/test/pokemon/pokemon.test.ts
+++ b/test/pokemon/pokemon.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Pokemon } from "../../src/pokemon";
+import { optimizeEVAndNature, Pokemon } from "../../src/pokemon";
 
 test("default champions path: 0 investment incineroar should have 170 hp & 135 attack", () => {
 	const incineroar = new Pokemon({
@@ -137,4 +137,109 @@ test("get base stat from pokeapi if id is provided", async () => {
 	const actualStat = incineroar.getStats();
 	expect(actualStat.hp).toBe(expectedHP);
 	expect(actualStat.attack).toBe(expectedAtk);
+});
+
+test("champions optimizer should find lower-EV equivalent spreads", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			defense: 11,
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon);
+	expect(result.foundImprovement).toBe(true);
+	if (!result.foundImprovement) {
+		throw new Error("Expected improvement");
+	}
+
+	expect(result.optimized.effortValues.speed).toBe(9);
+	expect(result.savedEffortValues).toBe(2);
+	expect(result.original.stats).toEqual(result.optimized.stats);
+});
+
+test("optimizer should preserve valid breakpoint EVs", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 32,
+		},
+		nature: {
+			plus: "attack",
+			minus: "specialAttack",
+		},
+	});
+
+	const result = optimizeEVAndNature(pokemon);
+	expect(result.foundImprovement).toBe(false);
+});
+
+test("optimizer should have deterministic tie-breaks", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 1,
+			defense: 2,
+		},
+		nature: {
+			plus: "attack",
+			minus: "specialAttack",
+		},
+	});
+
+	const first = optimizeEVAndNature(pokemon);
+	const second = optimizeEVAndNature(pokemon);
+
+	expect(first).toEqual(second);
+	if (first.foundImprovement) {
+		expect(first.optimized.nature).toEqual(pokemon.nature);
+	}
+});
+
+test("optimizer should throw on inconsistent manual stats", () => {
+	const pokemon = new Pokemon({
+		statRuleset: "champions",
+		baseStat: {
+			hp: 95,
+			attack: 115,
+			defense: 90,
+			specialAttack: 80,
+			specialDefense: 90,
+			speed: 60,
+		},
+		effortValues: {
+			attack: 4,
+		},
+		stats: {
+			attack: 999,
+		},
+	});
+
+	expect(() => optimizeEVAndNature(pokemon)).toThrow(
+		"Provided manual stats are inconsistent",
+	);
 });


### PR DESCRIPTION
closes #155

### Motivation
- Provide a utility to minimize total EV investment while preserving visible stats and optionally change nature to reduce wasted EVs under different `statRuleset`s.
- Expose `getMaxEvPerStat` so the optimizer can use per-stat EV limits consistently with existing logic.
- Cover the optimizer with unit tests to ensure correctness and deterministic behavior.

### Description
- Exported `getMaxEvPerStat` from `src/pokemon/effortValue.ts` for reuse by the optimizer. 
- Added a new optimizer `optimizeEVAndNature` in `src/pokemon/optimizeEVAndNature.ts` that enumerates candidate natures and computes minimal EV spreads that reproduce target stats while respecting per-stat and total EV caps. 
- Exported `optimizeEVAndNature` from `src/pokemon/index.ts` so it can be imported by consumers. 
- Added unit tests in `test/pokemon/pokemon.test.ts` that exercise the optimizer behavior and deterministic tie-breaking, and that it rejects inconsistent manual stats.

### Testing
- Ran unit tests with `bun:test` including the modified `test/pokemon/pokemon.test.ts` suite containing new tests: `champions optimizer should find lower-EV equivalent spreads`, `optimizer should preserve valid breakpoint EVs`, `optimizer should have deterministic tie-breaks`, and `optimizer should throw on inconsistent manual stats`. 
- All tests in the suite passed. 
- Existing Pokemon-related tests were also executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1381496d04832f8d8ae8ae91059c2f)