### PR TITLE
Remove legacy `isChampion` flag from battle/damage code and tests

### DIFF
--- a/src/damage/battle.ts
+++ b/src/damage/battle.ts
@@ -43,7 +43,6 @@ export class Battle implements IBattle {
 	attacker?: Pokemon;
 	defender?: Pokemon;
 	move?: Move;
-	isChampion = true;
 	constructor(option: Partial<BattleStatus>) {
 		if (option.attacker) {
 			this.attacker = option.attacker;
@@ -60,9 +59,6 @@ export class Battle implements IBattle {
 				...option.field,
 			};
 		}
-		if (option.isChampion !== undefined) {
-			this.isChampion = option.isChampion;
-		}
 	}
 	getDamage(): DamageResult {
 		if (!this.attacker || !this.defender) {
@@ -76,7 +72,6 @@ export class Battle implements IBattle {
 			defender: this.defender,
 			move: this.move,
 			field: this.field,
-			isChampion: this.isChampion,
 		});
 	}
 	setDamage(damage: number) {

--- a/src/damage/config.ts
+++ b/src/damage/config.ts
@@ -87,7 +87,6 @@ export type BattleStatus = {
 	defender: Pokemon;
 	move: Move;
 	field?: BattleFieldStatus;
-	isChampion: boolean;
 };
 
 type PokemonDmgFactor<T extends "Attacker" | "Defender"> = (T extends "Attacker"

--- a/test/damage/champion.test.ts
+++ b/test/damage/champion.test.ts
@@ -3,7 +3,7 @@ import { createMove } from "../../src";
 import { Battle } from "../../src/damage/battle";
 import { genTestMon, getDamangeNumberFromResult } from "./utils";
 
-test("champion (default) uses standard 16 damage rolls", () => {
+test("damage uses standard 16 damage rolls", () => {
 	const attacker = genTestMon({
 		types: ["Normal"],
 		baseStat: {
@@ -28,29 +28,16 @@ test("champion (default) uses standard 16 damage rolls", () => {
 		category: "Special",
 	});
 
-	const battleChampion = new Battle({
+	const battle = new Battle({
 		attacker,
 		defender,
 		move,
 	});
-	const battleNonChampion = new Battle({
-		attacker,
-		defender,
-		move,
-		isChampion: false,
-	});
-
-	const rollsChampion = getDamangeNumberFromResult(battleChampion.getDamage());
-	const rollsNonChampion = getDamangeNumberFromResult(
-		battleNonChampion.getDamage(),
-	);
-
-	expect(rollsChampion).toHaveLength(16);
-	expect(rollsNonChampion).toHaveLength(16);
-	expect(rollsChampion).toEqual(rollsNonChampion);
+	const rolls = getDamangeNumberFromResult(battle.getDamage());
+	expect(rolls).toHaveLength(16);
 });
 
-test("champion KO chance uses standard 16-roll denominator", () => {
+test("KO chance uses standard 16-roll denominator", () => {
 	const attacker = genTestMon({
 		types: ["Normal"],
 		baseStat: {
@@ -75,21 +62,11 @@ test("champion KO chance uses standard 16-roll denominator", () => {
 		category: "Special",
 	});
 
-	const championResult = new Battle({
+	const result = new Battle({
 		attacker,
 		defender,
 		move,
-		isChampion: true,
 	}).getDamage();
-
-	const nonChampionResult = new Battle({
-		attacker,
-		defender,
-		move,
-		isChampion: false,
-	}).getDamage();
-
-	expect(championResult.rolls).toHaveLength(16);
-	expect(nonChampionResult.rolls).toHaveLength(16);
-	expect(championResult.koChance).toBe(nonChampionResult.koChance);
+	expect(result.rolls).toHaveLength(16);
+	expect(result.koChance % 6.25).toBe(0);
 });

--- a/test/damage/internal/power.test.ts
+++ b/test/damage/internal/power.test.ts
@@ -16,7 +16,6 @@ test("get power without any modifiers", () => {
 		defender: testMon,
 		move: testMove,
 		field: {},
-		isChampion: true,
 	});
 	expect(power.operator).toBe(95);
 	expect(power.factors).toEqual({
@@ -42,7 +41,6 @@ test("get power with type enhancing item", () => {
 		defender: testMon,
 		move: testMove,
 		field: {},
-		isChampion: true,
 	});
 	expect(power.operator).toBe(114);
 	expect(power.factors?.attacker?.item).toBe(true);


### PR DESCRIPTION
### Motivation
- Simplify the damage calculation API by removing the legacy `isChampion` flag that toggled alternate roll behavior and standardize on the canonical 16-roll mechanic.

### Description
- Remove `isChampion` from `BattleStatus` and the `Battle` class, and stop passing `isChampion` into damage helper calls.
- Update `Battle.getDamage()` and constructor to no longer reference or set `isChampion`.
- Update tests to reflect the removal by eliminating `isChampion` usage and asserting the standard 16-roll behavior where applicable (`test/damage/champion.test.ts` and `test/damage/internal/power.test.ts`).

### Testing
- Ran the unit test suite with `bun test` after the changes and all tests passed.
- The updated tests `test/damage/champion.test.ts` and `test/damage/internal/power.test.ts` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13eddb40a0832f9a6c7db58a293fab)