### PR TITLE
Implement deterministic AI damage schema and adapter

### DIFF
--- a/docs/ai-tool-boundaries.md
+++ b/docs/ai-tool-boundaries.md
@@ -1,0 +1,78 @@
+# AI Tool Boundaries: Deterministic Damage Adapter
+
+This document defines what the deterministic AI damage contract **does** and **does not** do.
+
+Source of truth: [`docs/rfc/ai-damage-calculation-schema.md`](./rfc/ai-damage-calculation-schema.md).
+
+## In scope (v1)
+
+The deterministic adapter is responsible for:
+
+- Accepting machine-structured battle state with top-level `attacker` / `defender` / `move` / optional `field`.
+- Enforcing strict, JSON-safe, schema-based validation.
+- Rejecting unknown keys and non-canonical stat naming.
+- Supporting `statMode: "derived" | "manual"`.
+- Applying documented mechanical defaults for stable adapter construction.
+- Executing deterministic damage calculation through the existing engine.
+- Returning output compatible with `DamageResult` (`rolls`, `koChance`, `factors`).
+
+## Out of scope (v1)
+
+The deterministic adapter intentionally does **not** handle:
+
+- Alias/fuzzy name normalization.
+- Common/meta set inference.
+- Trigger/event interpretation or turn-state progression.
+- Natural-language parsing.
+- Playground UX concerns.
+- Tool orchestration policy (e.g., which scenarios should call damage tools).
+
+These concerns belong to separate layers/features referenced by the RFC.
+
+## Ownership split: deterministic adapter vs normalization layer
+
+### Deterministic adapter
+
+- Requires already-resolved mechanics-compatible inputs.
+- Validates contract shape and mechanical plausibility.
+- Produces deterministic calculation outputs.
+
+### Normalization layer (separate)
+
+- Handles aliasing and fuzzy mapping.
+- Resolves human-friendly or partial text into canonical IDs/fields.
+- May enrich inputs before deterministic execution.
+
+A good mental model: normalization prepares data; deterministic adapter computes with strict contracts.
+
+## Stat-mode authority rules
+
+### `derived`
+
+- Derived fields drive calculation.
+- `stats` should not be provided as override.
+
+### `manual`
+
+- `stats` are authoritative.
+- Derived metadata can coexist for context but must not re-derive/override `stats`.
+
+## Validation boundaries
+
+The contract should reject obviously impossible states when practical (best-effort), such as:
+
+- invalid level values
+- invalid ruleset values
+- negative/mechanically invalid stat values
+- EV totals/ranges that violate selected `statRuleset`
+
+Full cartridge legality validation remains out of scope in v1.
+
+## Integration guidance
+
+When wiring tool/eval/playground integrations:
+
+- Treat this adapter as the deterministic compute kernel.
+- Keep input normalization/parsing outside this contract.
+- Preserve raw structured output for downstream scoring/evaluation.
+- Prefer additive wrappers for future expansions rather than mutating v1 contract semantics.

--- a/docs/ai-tool-boundaries.md
+++ b/docs/ai-tool-boundaries.md
@@ -14,7 +14,7 @@ The deterministic adapter is responsible for:
 - Supporting `statMode: "derived" | "manual"`.
 - Applying documented mechanical defaults for stable adapter construction.
 - Executing deterministic damage calculation through the existing engine.
-- Returning output compatible with `DamageResult` (`rolls`, `koChance`, `factors`).
+- Returning output compatible with `DamageResult` (`rolls`, `koChance`, `factors`), where `koChance` is a percentage (`0..100`).
 
 ## Out of scope (v1)
 

--- a/docs/ai-tool-examples.md
+++ b/docs/ai-tool-examples.md
@@ -133,7 +133,7 @@ Optional key: `field`.
 The AI-facing output is compatible with `DamageResult` and includes:
 
 - `rolls` (ordered low → high)
-- `koChance`
+- `koChance` (percentage in `0..100`, not `0..1`)
 - `factors`
 
 Example (abridged):

--- a/docs/ai-tool-examples.md
+++ b/docs/ai-tool-examples.md
@@ -1,0 +1,173 @@
+# AI Tool Examples: Deterministic Damage Calculation
+
+This document provides integration-oriented examples for the deterministic AI damage calculation contract.
+
+Source of truth: [`docs/rfc/ai-damage-calculation-schema.md`](./rfc/ai-damage-calculation-schema.md).
+
+## Purpose
+
+Use this interface when an AI/tooling layer already has (or can provide) resolved mechanical battle state and needs deterministic damage output from the existing engine.
+
+- Input contract: `AiDamageCalcInputSchema`
+- Output contract: `AiDamageCalcOutputSchema`
+- Core adapter: `calculateAiDamage(input)`
+- Safe wrapper: `safeCalculateAiDamage(inputUnknown)`
+
+## Top-level input shape
+
+```json
+{
+  "attacker": { "...": "AiBattlerInput" },
+  "defender": { "...": "AiBattlerInput" },
+  "move": { "...": "AiMoveInput" },
+  "field": { "...": "AiFieldInput" }
+}
+```
+
+Required keys: `attacker`, `defender`, `move`.
+Optional key: `field`.
+
+## Example A: Derived attacker + manual defender
+
+```json
+{
+  "attacker": {
+    "statMode": "derived",
+    "pokemonId": 987,
+    "pokemonName": "flutter-mane",
+    "level": 50,
+    "types": ["Ghost", "Fairy"],
+    "baseStat": {
+      "hp": 55,
+      "attack": 55,
+      "defense": 55,
+      "specialAttack": 135,
+      "specialDefense": 135,
+      "speed": 135
+    },
+    "statRuleset": "mainSeries",
+    "effortValues": {
+      "hp": 4,
+      "specialAttack": 252,
+      "speed": 252
+    },
+    "individualValues": {
+      "attack": 0
+    },
+    "ability": "Protosynthesis",
+    "item": "Choice Specs",
+    "teraType": "Fairy",
+    "specialForm": "Tera",
+    "status": "Healthy"
+  },
+  "defender": {
+    "statMode": "manual",
+    "pokemonId": 645,
+    "pokemonName": "landorus-therian",
+    "types": ["Ground", "Flying"],
+    "stats": {
+      "hp": 165,
+      "attack": 165,
+      "defense": 110,
+      "specialAttack": 112,
+      "specialDefense": 100,
+      "speed": 143
+    },
+    "statStage": {
+      "specialDefense": -1
+    }
+  },
+  "move": {
+    "moveId": 585,
+    "moveName": "moonblast",
+    "base": 95,
+    "type": "Fairy",
+    "category": "Special",
+    "target": "selectedTarget"
+  },
+  "field": {
+    "isDouble": true
+  }
+}
+```
+
+## Example B: Minimal mechanical-default input
+
+```json
+{
+  "attacker": {
+    "statMode": "derived",
+    "types": ["Normal"],
+    "baseStat": {
+      "hp": 100,
+      "attack": 100,
+      "defense": 100,
+      "specialAttack": 100,
+      "specialDefense": 100,
+      "speed": 100
+    }
+  },
+  "defender": {
+    "statMode": "manual",
+    "types": ["Normal"],
+    "stats": {
+      "hp": 100,
+      "attack": 100,
+      "defense": 100,
+      "specialAttack": 100,
+      "specialDefense": 100,
+      "speed": 100
+    }
+  },
+  "move": {
+    "base": 100,
+    "type": "Normal",
+    "category": "Special",
+    "target": "selectedTarget"
+  }
+}
+```
+
+## Output shape
+
+The AI-facing output is compatible with `DamageResult` and includes:
+
+- `rolls` (ordered low → high)
+- `koChance`
+- `factors`
+
+Example (abridged):
+
+```json
+{
+  "rolls": [
+    { "number": 168, "percentage": 92.3 },
+    { "number": 169, "percentage": 92.9 }
+  ],
+  "koChance": 37.5,
+  "factors": {
+    "attacker": {},
+    "defender": {},
+    "field": {},
+    "move": {}
+  }
+}
+```
+
+## Validation reminders for callers
+
+- Use canonical full stat keys only (`hp`, `attack`, `defense`, `specialAttack`, `specialDefense`, `speed`).
+- Shorthand stat keys (`atk`, `def`, `spa`, `spd`, `spe`) are invalid.
+- Unknown keys are rejected (strict schema).
+- `isChampion` and `calcContext` are out of contract for v1.
+- In `manual` mode, `stats` are authoritative.
+- In `derived` mode, derived inputs are authoritative and `stats` should not be provided.
+
+## Suggested integration pattern
+
+1. Build tool-call payload from upstream state.
+2. Validate using `AiDamageCalcInputSchema` (or call safe wrapper).
+3. Call deterministic adapter.
+4. Return structured JSON output directly to evaluator/agent.
+
+This keeps deterministic battle mechanics in one engine path and avoids LLM-side emulation.

--- a/docs/rfc/ai-damage-calculation-schema.md
+++ b/docs/rfc/ai-damage-calculation-schema.md
@@ -177,6 +177,7 @@ Canonical output fields remain:
 - `factors`
 
 `rolls` is output-only, deterministic, and ordered from lowest to highest damage.
+`koChance` follows the current engine representation as a percentage in `0..100` (for example, `37.5`), not a `0..1` fraction.
 
 ## Unknown keys, aliases, and errors
 

--- a/src/aiDamage.ts
+++ b/src/aiDamage.ts
@@ -1,0 +1,191 @@
+import { z } from "zod";
+import { Battle, createMove } from "./damage";
+import type { BattleFieldStatus, DamageResult, Move, Stat, TeraTypes, Type } from "./damage/config";
+import { Pokemon } from "./pokemon";
+
+const statSchema = z
+	.object({
+		hp: z.number().int().nonnegative(),
+		attack: z.number().int().nonnegative(),
+		defense: z.number().int().nonnegative(),
+		specialAttack: z.number().int().nonnegative(),
+		specialDefense: z.number().int().nonnegative(),
+		speed: z.number().int().nonnegative(),
+	})
+	.strict();
+
+const derivedOnlyStatSchema = z
+	.object({
+		hp: z.number().int().min(0),
+		attack: z.number().int().min(0),
+		defense: z.number().int().min(0),
+		specialAttack: z.number().int().min(0),
+		specialDefense: z.number().int().min(0),
+		speed: z.number().int().min(0),
+	})
+	.strict();
+
+const typeSchema = z.enum([
+	"Normal","Fire","Water","Grass","Electric","Ice","Fighting","Poison","Ground","Flying","Psychic","Bug","Rock","Ghost","Dragon","Dark","Steel","Fairy",
+]);
+const teraTypeSchema = z.union([typeSchema, z.literal("Stellar")]);
+const statusSchema = z.enum(["Healthy", "Burned", "Poisoned", "Badly Poisoned", "Asleep", "Frozen", "Paralyzed"]);
+const specialFormSchema = z.enum(["None", "Mega", "Dynamax", "GigaDynamax", "Tera"]);
+const statRulesetSchema = z.enum(["champions", "mainSeries"]);
+
+const statStageSchema = z.object({
+	attack: z.number().int().min(-6).max(6).optional(),
+	defense: z.number().int().min(-6).max(6).optional(),
+	specialAttack: z.number().int().min(-6).max(6).optional(),
+	specialDefense: z.number().int().min(-6).max(6).optional(),
+	speed: z.number().int().min(-6).max(6).optional(),
+}).strict();
+
+const flagsSchema = z.object({
+	helpingHand: z.boolean().optional(), powerSpot: z.boolean().optional(), steelySpirit: z.boolean().optional(), charge: z.boolean().optional(), hasEvolution: z.boolean().optional(), lightScreen: z.boolean().optional(), reflect: z.boolean().optional(), hasFriendGuard: z.boolean().optional(),
+}).strict();
+
+const commonBattlerSchema = z.object({
+	pokemonId: z.number().int().positive().optional(),
+	pokemonName: z.string().optional(),
+	level: z.number().int().min(1).max(100).optional(),
+	types: z.union([z.tuple([typeSchema]), z.tuple([typeSchema, typeSchema])]),
+	statRuleset: statRulesetSchema.optional(),
+	effortValues: derivedOnlyStatSchema.partial().optional(),
+	individualValues: derivedOnlyStatSchema.partial().optional(),
+	nature: z.object({ plus: z.enum(["attack", "defense", "specialAttack", "specialDefense", "speed"]).optional(), minus: z.enum(["attack", "defense", "specialAttack", "specialDefense", "speed"]).optional() }).strict().optional(),
+	statStage: statStageSchema.optional(),
+	ability: z.string().optional(),
+	item: z.string().optional(),
+	teraType: teraTypeSchema.optional(),
+	specialForm: specialFormSchema.optional(),
+	status: statusSchema.optional(),
+	flags: flagsSchema.optional(),
+	takenDamage: z.number().int().min(0).optional(),
+}).strict();
+
+const derivedBattlerSchema = commonBattlerSchema.extend({
+	statMode: z.literal("derived"),
+	baseStat: derivedOnlyStatSchema,
+	stats: z.never().optional(),
+});
+
+const manualBattlerSchema = commonBattlerSchema.extend({
+	statMode: z.literal("manual"),
+	stats: statSchema,
+	baseStat: derivedOnlyStatSchema.optional(),
+});
+
+const moveSchema = z.object({
+	moveId: z.number().int().positive().optional(),
+	moveName: z.string().optional(),
+	base: z.number().int().nonnegative(),
+	type: teraTypeSchema,
+	category: z.enum(["Special", "Physical"]),
+	target: z.enum(["selectedTarget", "allAdjacentFoes", "allAdjacent"]),
+	flags: z.object({ hasRecoil: z.boolean().optional(), hasSecondary: z.boolean().optional(), isContact: z.boolean().optional(), isPunch: z.boolean().optional(), isSound: z.boolean().optional(), isSlicing: z.boolean().optional(), isBite: z.boolean().optional(), isPulse: z.boolean().optional(), isMultihit: z.boolean().optional(), isPriority: z.boolean().optional(), isCriticalHit: z.boolean().optional() }).strict().optional(),
+	repeatTimes: z.number().int().positive().optional(),
+}).strict();
+
+const fieldSchema = z.object({ weather: z.enum(["Sun", "Rain", "Sand", "Snow"]).optional(), terrain: z.enum(["Electric", "Grassy", "Misty", "Psychic"]).optional(), aura: z.array(z.enum(["Fairy", "Dark", "Aura Break"])).optional(), ruin: z.array(z.enum(["Tablets", "Sword", "Vessel", "Beads"])).optional(), isDouble: z.boolean().optional() }).strict();
+
+export const AiDamageCalcInputSchema = z.object({ attacker: z.union([derivedBattlerSchema, manualBattlerSchema]), defender: z.union([derivedBattlerSchema, manualBattlerSchema]), move: moveSchema, field: fieldSchema.optional() }).strict().superRefine((arg, ctx) => {
+	const checkEv = (ev: Partial<Stat> | undefined, ruleset: "champions" | "mainSeries", path: (string|number)[]) => {
+		if (!ev) return;
+		const max = ruleset === "champions" ? 32 : 252;
+		const totalMax = ruleset === "champions" ? 66 : 510;
+		const values = Object.values(ev);
+		for (const value of values) {
+			if (!Number.isInteger(value) || value < 0 || value > max) ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: `Invalid effortValues for ${ruleset}` });
+		}
+		const total = values.reduce((s, v) => s + (v ?? 0), 0);
+		if (total > totalMax) ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: `Total effortValues exceeds ${totalMax} for ${ruleset}` });
+	};
+	for (const side of ["attacker", "defender"] as const) {
+		const p = arg[side];
+		checkEv(p.effortValues, p.statRuleset ?? "champions", [side, "effortValues"]);
+	}
+});
+
+export type AiDamageCalcInput = z.infer<typeof AiDamageCalcInputSchema>;
+
+export type NormalizedAiDamageCalcInput = {
+	attacker: NormalizedBattler;
+	defender: NormalizedBattler;
+	move: Move;
+	field: BattleFieldStatus;
+};
+
+type NormalizedBattler = {
+	id?: number;
+	name?: string;
+	level: number;
+	types: [Type] | [Type, Type];
+	baseStat: Stat;
+	statRuleset: "champions" | "mainSeries";
+	effortValues: Stat;
+	individualValues: Stat;
+	stats?: Stat;
+	statStage: Omit<Stat, "hp">;
+	ability?: string;
+	item?: string;
+	teraType?: TeraTypes;
+	specialForm: "None" | "Mega" | "Dynamax" | "GigaDynamax" | "Tera";
+	status: "Healthy" | "Burned" | "Poisoned" | "Badly Poisoned" | "Asleep" | "Frozen" | "Paralyzed";
+	flags?: { [k: string]: boolean | undefined };
+	takenDamage: number;
+};
+
+export const AiDamageCalcOutputSchema = z.object({
+	rolls: z.array(z.object({ number: z.number(), percentage: z.number() }).strict()),
+	koChance: z.number(),
+	factors: z.object({ attacker: z.record(z.any()), defender: z.record(z.any()), move: z.record(z.any()), field: z.record(z.any()) }).strict(),
+}).strict();
+export type AiDamageCalcOutput = z.infer<typeof AiDamageCalcOutputSchema>;
+
+function normalizeBattler(input: AiDamageCalcInput["attacker"]): NormalizedBattler {
+	const defaults: Stat = { hp: 0, attack: 0, defense: 0, specialAttack: 0, specialDefense: 0, speed: 0 };
+	const ivDefault: Stat = { hp: 31, attack: 31, defense: 31, specialAttack: 31, specialDefense: 31, speed: 31 };
+	const stageDefault = { attack: 0, defense: 0, specialAttack: 0, specialDefense: 0, speed: 0 };
+	return {
+		id: input.pokemonId,
+		name: input.pokemonName,
+		level: input.level ?? 50,
+		types: input.types,
+		baseStat: { ...defaults, ...(input.baseStat ?? defaults) },
+		statRuleset: input.statRuleset ?? "champions",
+		effortValues: { ...defaults, ...(input.effortValues ?? {}) },
+		individualValues: { ...ivDefault, ...(input.individualValues ?? {}) },
+		stats: input.statMode === "manual" ? input.stats : undefined,
+		statStage: { ...stageDefault, ...(input.statStage ?? {}) },
+		ability: input.ability,
+		item: input.item,
+		teraType: input.teraType,
+		specialForm: input.specialForm ?? "None",
+		status: input.status ?? "Healthy",
+		flags: input.flags,
+		takenDamage: input.takenDamage ?? 0,
+	};
+}
+
+export function normalizeAiDamageCalcInput(input: AiDamageCalcInput): NormalizedAiDamageCalcInput {
+	const attacker = normalizeBattler(input.attacker);
+	const defender = normalizeBattler(input.defender);
+	const move = createMove({ id: input.move.moveId ?? 0, base: input.move.base, type: input.move.type, category: input.move.category, target: input.move.target, flags: input.move.flags, repeatTimes: input.move.repeatTimes });
+	return { attacker, defender, move, field: { isDouble: true, ...(input.field ?? {}) } };
+}
+
+export function calculateAiDamage(input: AiDamageCalcInput): DamageResult {
+	const normalized = normalizeAiDamageCalcInput(input);
+	const battle = new Battle({
+		attacker: new Pokemon(normalized.attacker),
+		defender: new Pokemon(normalized.defender),
+		move: normalized.move,
+		field: normalized.field,
+	});
+	return battle.getDamage();
+}
+
+export function safeCalculateAiDamage(input: unknown): DamageResult {
+	return calculateAiDamage(AiDamageCalcInputSchema.parse(input));
+}

--- a/src/aiDamage.ts
+++ b/src/aiDamage.ts
@@ -275,10 +275,10 @@ export const AiDamageCalcOutputSchema = z
 		koChance: z.number(),
 		factors: z
 			.object({
-				attacker: z.record(z.any()),
-				defender: z.record(z.any()),
-				move: z.record(z.any()),
-				field: z.record(z.any()),
+				attacker: z.record(z.unknown()),
+				defender: z.record(z.unknown()),
+				move: z.record(z.unknown()),
+				field: z.record(z.unknown()),
 			})
 			.strict(),
 	})

--- a/src/aiDamage.ts
+++ b/src/aiDamage.ts
@@ -1,7 +1,15 @@
 import { z } from "zod";
 import { Battle, createMove } from "./damage";
-import type { BattleFieldStatus, DamageResult, Move, Stat, TeraTypes, Type } from "./damage/config";
+import type {
+	BattleFieldStatus,
+	DamageResult,
+	Move,
+	Stat,
+	TeraTypes,
+	Type,
+} from "./damage/config";
 import { Pokemon } from "./pokemon";
+import type { Ability, Item } from "./pokemon/typeHelper";
 
 const statSchema = z
 	.object({
@@ -26,43 +34,109 @@ const derivedOnlyStatSchema = z
 	.strict();
 
 const typeSchema = z.enum([
-	"Normal","Fire","Water","Grass","Electric","Ice","Fighting","Poison","Ground","Flying","Psychic","Bug","Rock","Ghost","Dragon","Dark","Steel","Fairy",
+	"Normal",
+	"Fire",
+	"Water",
+	"Grass",
+	"Electric",
+	"Ice",
+	"Fighting",
+	"Poison",
+	"Ground",
+	"Flying",
+	"Psychic",
+	"Bug",
+	"Rock",
+	"Ghost",
+	"Dragon",
+	"Dark",
+	"Steel",
+	"Fairy",
 ]);
 const teraTypeSchema = z.union([typeSchema, z.literal("Stellar")]);
-const statusSchema = z.enum(["Healthy", "Burned", "Poisoned", "Badly Poisoned", "Asleep", "Frozen", "Paralyzed"]);
-const specialFormSchema = z.enum(["None", "Mega", "Dynamax", "GigaDynamax", "Tera"]);
+const statusSchema = z.enum([
+	"Healthy",
+	"Burned",
+	"Poisoned",
+	"Badly Poisoned",
+	"Asleep",
+	"Frozen",
+	"Paralyzed",
+]);
+const specialFormSchema = z.enum([
+	"None",
+	"Mega",
+	"Dynamax",
+	"GigaDynamax",
+	"Tera",
+]);
 const statRulesetSchema = z.enum(["champions", "mainSeries"]);
 
-const statStageSchema = z.object({
-	attack: z.number().int().min(-6).max(6).optional(),
-	defense: z.number().int().min(-6).max(6).optional(),
-	specialAttack: z.number().int().min(-6).max(6).optional(),
-	specialDefense: z.number().int().min(-6).max(6).optional(),
-	speed: z.number().int().min(-6).max(6).optional(),
-}).strict();
+const statStageSchema = z
+	.object({
+		attack: z.number().int().min(-6).max(6).optional(),
+		defense: z.number().int().min(-6).max(6).optional(),
+		specialAttack: z.number().int().min(-6).max(6).optional(),
+		specialDefense: z.number().int().min(-6).max(6).optional(),
+		speed: z.number().int().min(-6).max(6).optional(),
+	})
+	.strict();
 
-const flagsSchema = z.object({
-	helpingHand: z.boolean().optional(), powerSpot: z.boolean().optional(), steelySpirit: z.boolean().optional(), charge: z.boolean().optional(), hasEvolution: z.boolean().optional(), lightScreen: z.boolean().optional(), reflect: z.boolean().optional(), hasFriendGuard: z.boolean().optional(),
-}).strict();
+const flagsSchema = z
+	.object({
+		helpingHand: z.boolean().optional(),
+		powerSpot: z.boolean().optional(),
+		steelySpirit: z.boolean().optional(),
+		charge: z.boolean().optional(),
+		hasEvolution: z.boolean().optional(),
+		lightScreen: z.boolean().optional(),
+		reflect: z.boolean().optional(),
+		hasFriendGuard: z.boolean().optional(),
+	})
+	.strict();
 
-const commonBattlerSchema = z.object({
-	pokemonId: z.number().int().positive().optional(),
-	pokemonName: z.string().optional(),
-	level: z.number().int().min(1).max(100).optional(),
-	types: z.union([z.tuple([typeSchema]), z.tuple([typeSchema, typeSchema])]),
-	statRuleset: statRulesetSchema.optional(),
-	effortValues: derivedOnlyStatSchema.partial().optional(),
-	individualValues: derivedOnlyStatSchema.partial().optional(),
-	nature: z.object({ plus: z.enum(["attack", "defense", "specialAttack", "specialDefense", "speed"]).optional(), minus: z.enum(["attack", "defense", "specialAttack", "specialDefense", "speed"]).optional() }).strict().optional(),
-	statStage: statStageSchema.optional(),
-	ability: z.string().optional(),
-	item: z.string().optional(),
-	teraType: teraTypeSchema.optional(),
-	specialForm: specialFormSchema.optional(),
-	status: statusSchema.optional(),
-	flags: flagsSchema.optional(),
-	takenDamage: z.number().int().min(0).optional(),
-}).strict();
+const commonBattlerSchema = z
+	.object({
+		pokemonId: z.number().int().positive().optional(),
+		pokemonName: z.string().optional(),
+		level: z.number().int().min(1).max(100).optional(),
+		types: z.union([z.tuple([typeSchema]), z.tuple([typeSchema, typeSchema])]),
+		statRuleset: statRulesetSchema.optional(),
+		effortValues: derivedOnlyStatSchema.partial().optional(),
+		individualValues: derivedOnlyStatSchema.partial().optional(),
+		nature: z
+			.object({
+				plus: z
+					.enum([
+						"attack",
+						"defense",
+						"specialAttack",
+						"specialDefense",
+						"speed",
+					])
+					.optional(),
+				minus: z
+					.enum([
+						"attack",
+						"defense",
+						"specialAttack",
+						"specialDefense",
+						"speed",
+					])
+					.optional(),
+			})
+			.strict()
+			.optional(),
+		statStage: statStageSchema.optional(),
+		ability: z.string().optional(),
+		item: z.string().optional(),
+		teraType: teraTypeSchema.optional(),
+		specialForm: specialFormSchema.optional(),
+		status: statusSchema.optional(),
+		flags: flagsSchema.optional(),
+		takenDamage: z.number().int().min(0).optional(),
+	})
+	.strict();
 
 const derivedBattlerSchema = commonBattlerSchema.extend({
 	statMode: z.literal("derived"),
@@ -76,36 +150,86 @@ const manualBattlerSchema = commonBattlerSchema.extend({
 	baseStat: derivedOnlyStatSchema.optional(),
 });
 
-const moveSchema = z.object({
-	moveId: z.number().int().positive().optional(),
-	moveName: z.string().optional(),
-	base: z.number().int().nonnegative(),
-	type: teraTypeSchema,
-	category: z.enum(["Special", "Physical"]),
-	target: z.enum(["selectedTarget", "allAdjacentFoes", "allAdjacent"]),
-	flags: z.object({ hasRecoil: z.boolean().optional(), hasSecondary: z.boolean().optional(), isContact: z.boolean().optional(), isPunch: z.boolean().optional(), isSound: z.boolean().optional(), isSlicing: z.boolean().optional(), isBite: z.boolean().optional(), isPulse: z.boolean().optional(), isMultihit: z.boolean().optional(), isPriority: z.boolean().optional(), isCriticalHit: z.boolean().optional() }).strict().optional(),
-	repeatTimes: z.number().int().positive().optional(),
-}).strict();
+const moveSchema = z
+	.object({
+		moveId: z.number().int().positive().optional(),
+		moveName: z.string().optional(),
+		base: z.number().int().nonnegative(),
+		type: teraTypeSchema,
+		category: z.enum(["Special", "Physical"]),
+		target: z.enum(["selectedTarget", "allAdjacentFoes", "allAdjacent"]),
+		flags: z
+			.object({
+				hasRecoil: z.boolean().optional(),
+				hasSecondary: z.boolean().optional(),
+				isContact: z.boolean().optional(),
+				isPunch: z.boolean().optional(),
+				isSound: z.boolean().optional(),
+				isSlicing: z.boolean().optional(),
+				isBite: z.boolean().optional(),
+				isPulse: z.boolean().optional(),
+				isMultihit: z.boolean().optional(),
+				isPriority: z.boolean().optional(),
+				isCriticalHit: z.boolean().optional(),
+			})
+			.strict()
+			.optional(),
+		repeatTimes: z.number().int().positive().optional(),
+	})
+	.strict();
 
-const fieldSchema = z.object({ weather: z.enum(["Sun", "Rain", "Sand", "Snow"]).optional(), terrain: z.enum(["Electric", "Grassy", "Misty", "Psychic"]).optional(), aura: z.array(z.enum(["Fairy", "Dark", "Aura Break"])).optional(), ruin: z.array(z.enum(["Tablets", "Sword", "Vessel", "Beads"])).optional(), isDouble: z.boolean().optional() }).strict();
+const fieldSchema = z
+	.object({
+		weather: z.enum(["Sun", "Rain", "Sand", "Snow"]).optional(),
+		terrain: z.enum(["Electric", "Grassy", "Misty", "Psychic"]).optional(),
+		aura: z.array(z.enum(["Fairy", "Dark", "Aura Break"])).optional(),
+		ruin: z.array(z.enum(["Tablets", "Sword", "Vessel", "Beads"])).optional(),
+		isDouble: z.boolean().optional(),
+	})
+	.strict();
 
-export const AiDamageCalcInputSchema = z.object({ attacker: z.union([derivedBattlerSchema, manualBattlerSchema]), defender: z.union([derivedBattlerSchema, manualBattlerSchema]), move: moveSchema, field: fieldSchema.optional() }).strict().superRefine((arg, ctx) => {
-	const checkEv = (ev: Partial<Stat> | undefined, ruleset: "champions" | "mainSeries", path: (string|number)[]) => {
-		if (!ev) return;
-		const max = ruleset === "champions" ? 32 : 252;
-		const totalMax = ruleset === "champions" ? 66 : 510;
-		const values = Object.values(ev);
-		for (const value of values) {
-			if (!Number.isInteger(value) || value < 0 || value > max) ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: `Invalid effortValues for ${ruleset}` });
+export const AiDamageCalcInputSchema = z
+	.object({
+		attacker: z.union([derivedBattlerSchema, manualBattlerSchema]),
+		defender: z.union([derivedBattlerSchema, manualBattlerSchema]),
+		move: moveSchema,
+		field: fieldSchema.optional(),
+	})
+	.strict()
+	.superRefine((arg, ctx) => {
+		const checkEv = (
+			ev: Partial<Stat> | undefined,
+			ruleset: "champions" | "mainSeries",
+			path: (string | number)[],
+		) => {
+			if (!ev) return;
+			const max = ruleset === "champions" ? 32 : 252;
+			const totalMax = ruleset === "champions" ? 66 : 510;
+			const values = Object.values(ev);
+			for (const value of values) {
+				if (!Number.isInteger(value) || value < 0 || value > max)
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						path,
+						message: `Invalid effortValues for ${ruleset}`,
+					});
+			}
+			const total = values.reduce((s, v) => s + (v ?? 0), 0);
+			if (total > totalMax)
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path,
+					message: `Total effortValues exceeds ${totalMax} for ${ruleset}`,
+				});
+		};
+		for (const side of ["attacker", "defender"] as const) {
+			const p = arg[side];
+			checkEv(p.effortValues, p.statRuleset ?? "champions", [
+				side,
+				"effortValues",
+			]);
 		}
-		const total = values.reduce((s, v) => s + (v ?? 0), 0);
-		if (total > totalMax) ctx.addIssue({ code: z.ZodIssueCode.custom, path, message: `Total effortValues exceeds ${totalMax} for ${ruleset}` });
-	};
-	for (const side of ["attacker", "defender"] as const) {
-		const p = arg[side];
-		checkEv(p.effortValues, p.statRuleset ?? "champions", [side, "effortValues"]);
-	}
-});
+	});
 
 export type AiDamageCalcInput = z.infer<typeof AiDamageCalcInputSchema>;
 
@@ -127,39 +251,79 @@ type NormalizedBattler = {
 	individualValues: Stat;
 	stats?: Stat;
 	statStage: Omit<Stat, "hp">;
-	ability?: string;
-	item?: string;
+	ability?: Ability;
+	item?: Item;
 	teraType?: TeraTypes;
 	specialForm: "None" | "Mega" | "Dynamax" | "GigaDynamax" | "Tera";
-	status: "Healthy" | "Burned" | "Poisoned" | "Badly Poisoned" | "Asleep" | "Frozen" | "Paralyzed";
+	status:
+		| "Healthy"
+		| "Burned"
+		| "Poisoned"
+		| "Badly Poisoned"
+		| "Asleep"
+		| "Frozen"
+		| "Paralyzed";
 	flags?: { [k: string]: boolean | undefined };
 	takenDamage: number;
 };
 
-export const AiDamageCalcOutputSchema = z.object({
-	rolls: z.array(z.object({ number: z.number(), percentage: z.number() }).strict()),
-	koChance: z.number(),
-	factors: z.object({ attacker: z.record(z.any()), defender: z.record(z.any()), move: z.record(z.any()), field: z.record(z.any()) }).strict(),
-}).strict();
+export const AiDamageCalcOutputSchema = z
+	.object({
+		rolls: z.array(
+			z.object({ number: z.number(), percentage: z.number() }).strict(),
+		),
+		koChance: z.number(),
+		factors: z
+			.object({
+				attacker: z.record(z.any()),
+				defender: z.record(z.any()),
+				move: z.record(z.any()),
+				field: z.record(z.any()),
+			})
+			.strict(),
+	})
+	.strict();
 export type AiDamageCalcOutput = z.infer<typeof AiDamageCalcOutputSchema>;
 
-function normalizeBattler(input: AiDamageCalcInput["attacker"]): NormalizedBattler {
-	const defaults: Stat = { hp: 0, attack: 0, defense: 0, specialAttack: 0, specialDefense: 0, speed: 0 };
-	const ivDefault: Stat = { hp: 31, attack: 31, defense: 31, specialAttack: 31, specialDefense: 31, speed: 31 };
-	const stageDefault = { attack: 0, defense: 0, specialAttack: 0, specialDefense: 0, speed: 0 };
+function normalizeBattler(
+	input: AiDamageCalcInput["attacker"],
+): NormalizedBattler {
+	const defaults: Stat = {
+		hp: 0,
+		attack: 0,
+		defense: 0,
+		specialAttack: 0,
+		specialDefense: 0,
+		speed: 0,
+	};
+	const ivDefault: Stat = {
+		hp: 31,
+		attack: 31,
+		defense: 31,
+		specialAttack: 31,
+		specialDefense: 31,
+		speed: 31,
+	};
+	const stageDefault = {
+		attack: 0,
+		defense: 0,
+		specialAttack: 0,
+		specialDefense: 0,
+		speed: 0,
+	};
 	return {
 		id: input.pokemonId,
 		name: input.pokemonName,
 		level: input.level ?? 50,
-		types: input.types,
+		types: [...input.types] as [Type] | [Type, Type],
 		baseStat: { ...defaults, ...(input.baseStat ?? defaults) },
 		statRuleset: input.statRuleset ?? "champions",
 		effortValues: { ...defaults, ...(input.effortValues ?? {}) },
 		individualValues: { ...ivDefault, ...(input.individualValues ?? {}) },
 		stats: input.statMode === "manual" ? input.stats : undefined,
 		statStage: { ...stageDefault, ...(input.statStage ?? {}) },
-		ability: input.ability,
-		item: input.item,
+		ability: input.ability as Ability | undefined,
+		item: input.item as Item | undefined,
 		teraType: input.teraType,
 		specialForm: input.specialForm ?? "None",
 		status: input.status ?? "Healthy",
@@ -168,11 +332,26 @@ function normalizeBattler(input: AiDamageCalcInput["attacker"]): NormalizedBattl
 	};
 }
 
-export function normalizeAiDamageCalcInput(input: AiDamageCalcInput): NormalizedAiDamageCalcInput {
+export function normalizeAiDamageCalcInput(
+	input: AiDamageCalcInput,
+): NormalizedAiDamageCalcInput {
 	const attacker = normalizeBattler(input.attacker);
 	const defender = normalizeBattler(input.defender);
-	const move = createMove({ id: input.move.moveId ?? 0, base: input.move.base, type: input.move.type, category: input.move.category, target: input.move.target, flags: input.move.flags, repeatTimes: input.move.repeatTimes });
-	return { attacker, defender, move, field: { isDouble: true, ...(input.field ?? {}) } };
+	const move = createMove({
+		id: input.move.moveId ?? 0,
+		base: input.move.base,
+		type: input.move.type,
+		category: input.move.category,
+		target: input.move.target,
+		flags: input.move.flags,
+		repeatTimes: input.move.repeatTimes,
+	});
+	return {
+		attacker,
+		defender,
+		move,
+		field: { isDouble: true, ...(input.field ?? {}) },
+	};
 }
 
 export function calculateAiDamage(input: AiDamageCalcInput): DamageResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./damage";
 export * from "./pokemon";
+
+export * from "./aiDamage";

--- a/test/damage/aiDamage.test.ts
+++ b/test/damage/aiDamage.test.ts
@@ -1,57 +1,203 @@
 import { expect, test } from "bun:test";
-import { AiDamageCalcInputSchema, calculateAiDamage, normalizeAiDamageCalcInput, safeCalculateAiDamage } from "../../src/aiDamage";
+import type { AiDamageCalcInput } from "../../src/aiDamage";
+import {
+	AiDamageCalcInputSchema,
+	calculateAiDamage,
+	normalizeAiDamageCalcInput,
+	safeCalculateAiDamage,
+} from "../../src/aiDamage";
 
-const derivedManualInput = {
-  attacker: { statMode: "derived", types: ["Ghost", "Fairy"], baseStat: { hp: 55, attack: 55, defense: 55, specialAttack: 135, specialDefense: 135, speed: 135 }, level: 50, effortValues: { hp: 4, specialAttack: 252, speed: 252 }, individualValues: { attack: 0 }, statRuleset: "mainSeries", specialForm: "Tera" },
-  defender: { statMode: "manual", types: ["Ground", "Flying"], stats: { hp: 165, attack: 165, defense: 110, specialAttack: 112, specialDefense: 100, speed: 143 }, statStage: { specialDefense: -1 } },
-  move: { base: 95, type: "Fairy", category: "Special", target: "selectedTarget" },
-  field: { isDouble: true }
-} as const;
+const derivedManualInput: AiDamageCalcInput = {
+	attacker: {
+		statMode: "derived",
+		types: ["Ghost", "Fairy"],
+		baseStat: {
+			hp: 55,
+			attack: 55,
+			defense: 55,
+			specialAttack: 135,
+			specialDefense: 135,
+			speed: 135,
+		},
+		level: 50,
+		effortValues: { hp: 4, specialAttack: 252, speed: 252 },
+		individualValues: { attack: 0 },
+		statRuleset: "mainSeries",
+		specialForm: "Tera",
+	},
+	defender: {
+		statMode: "manual",
+		types: ["Ground", "Flying"],
+		stats: {
+			hp: 165,
+			attack: 165,
+			defense: 110,
+			specialAttack: 112,
+			specialDefense: 100,
+			speed: 143,
+		},
+		statStage: { specialDefense: -1 },
+	},
+	move: {
+		base: 95,
+		type: "Fairy",
+		category: "Special",
+		target: "selectedTarget",
+	},
+	field: { isDouble: true },
+};
 
 test("schema accepts valid derived attacker + manual defender", () => {
-  expect(() => AiDamageCalcInputSchema.parse(derivedManualInput)).not.toThrow();
+	expect(() => AiDamageCalcInputSchema.parse(derivedManualInput)).not.toThrow();
 });
 
 test("schema accepts minimal mechanical-default input", () => {
-  expect(() => AiDamageCalcInputSchema.parse({ attacker: { statMode: "derived", types: ["Normal"], baseStat: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, defender: { statMode: "manual", types: ["Normal"], stats: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, move: { base: 100, type: "Normal", category: "Special", target: "selectedTarget" } })).not.toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({
+			attacker: {
+				statMode: "derived",
+				types: ["Normal"],
+				baseStat: {
+					hp: 100,
+					attack: 100,
+					defense: 100,
+					specialAttack: 100,
+					specialDefense: 100,
+					speed: 100,
+				},
+			},
+			defender: {
+				statMode: "manual",
+				types: ["Normal"],
+				stats: {
+					hp: 100,
+					attack: 100,
+					defense: 100,
+					specialAttack: 100,
+					specialDefense: 100,
+					speed: 100,
+				},
+			},
+			move: {
+				base: 100,
+				type: "Normal",
+				category: "Special",
+				target: "selectedTarget",
+			},
+		}),
+	).not.toThrow();
 });
 
 test("strict unknown-key rejection", () => {
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, x: 1 })).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({ ...derivedManualInput, x: 1 }),
+	).toThrow();
 });
 
 test("shorthand keys rejected", () => {
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, defender: { ...derivedManualInput.defender, stats: { hp: 1, atk: 2 } } })).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({
+			...derivedManualInput,
+			defender: { ...derivedManualInput.defender, stats: { hp: 1, atk: 2 } },
+		}),
+	).toThrow();
 });
 
 test("isChampion and calcContext rejected", () => {
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, isChampion: true })).toThrow();
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, calcContext: {} })).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({ ...derivedManualInput, isChampion: true }),
+	).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({ ...derivedManualInput, calcContext: {} }),
+	).toThrow();
 });
 
 test("manual mode uses stats as authoritative", () => {
-  const r1 = calculateAiDamage({ ...derivedManualInput, defender: { ...derivedManualInput.defender, baseStat: { hp: 1, attack: 1, defense: 1, specialAttack: 1, specialDefense: 1, speed: 1 }, effortValues: { hp: 0 } } });
-  const r2 = calculateAiDamage(derivedManualInput);
-  expect(r1.rolls).toEqual(r2.rolls);
+	const r1 = calculateAiDamage({
+		...derivedManualInput,
+		defender: {
+			...derivedManualInput.defender,
+			baseStat: {
+				hp: 1,
+				attack: 1,
+				defense: 1,
+				specialAttack: 1,
+				specialDefense: 1,
+				speed: 1,
+			},
+			effortValues: { hp: 0 },
+		},
+	});
+	const r2 = calculateAiDamage(derivedManualInput);
+	expect(r1.rolls).toEqual(r2.rolls);
 });
 
 test("default materialization works", () => {
-  const normalized = normalizeAiDamageCalcInput({ attacker: { statMode: "derived", types: ["Normal"], baseStat: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, defender: { statMode: "manual", types: ["Normal"], stats: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, move: { base: 100, type: "Normal", category: "Special", target: "selectedTarget" } });
-  expect(normalized.attacker.level).toBe(50);
-  expect(normalized.attacker.status).toBe("Healthy");
-  expect(normalized.attacker.effortValues.hp).toBe(0);
-  expect(normalized.attacker.individualValues.hp).toBe(31);
-  expect(normalized.field.isDouble).toBe(true);
+	const normalized = normalizeAiDamageCalcInput({
+		attacker: {
+			statMode: "derived",
+			types: ["Normal"],
+			baseStat: {
+				hp: 100,
+				attack: 100,
+				defense: 100,
+				specialAttack: 100,
+				specialDefense: 100,
+				speed: 100,
+			},
+		},
+		defender: {
+			statMode: "manual",
+			types: ["Normal"],
+			stats: {
+				hp: 100,
+				attack: 100,
+				defense: 100,
+				specialAttack: 100,
+				specialDefense: 100,
+				speed: 100,
+			},
+		},
+		move: {
+			base: 100,
+			type: "Normal",
+			category: "Special",
+			target: "selectedTarget",
+		},
+	});
+	expect(normalized.attacker.level).toBe(50);
+	expect(normalized.attacker.status).toBe("Healthy");
+	expect(normalized.attacker.effortValues.hp).toBe(0);
+	expect(normalized.attacker.individualValues.hp).toBe(31);
+	expect(normalized.field.isDouble).toBe(true);
 });
 
 test("output compatible with DamageResult and safe wrapper", () => {
-  const result = safeCalculateAiDamage(derivedManualInput);
-  expect(Array.isArray(result.rolls)).toBe(true);
-  expect(typeof result.koChance).toBe("number");
-  expect(result.factors.attacker).toBeObject();
+	const result = safeCalculateAiDamage(derivedManualInput);
+	expect(Array.isArray(result.rolls)).toBe(true);
+	expect(typeof result.koChance).toBe("number");
+	expect(result.factors.attacker).toBeObject();
 });
 
 test("invalid EV totals rejected based on statRuleset", () => {
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, attacker: { ...derivedManualInput.attacker, effortValues: { hp: 252, attack: 252, defense: 252 }, statRuleset: "mainSeries" } })).toThrow();
-  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, attacker: { ...derivedManualInput.attacker, effortValues: { hp: 33 }, statRuleset: "champions" } })).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({
+			...derivedManualInput,
+			attacker: {
+				...derivedManualInput.attacker,
+				effortValues: { hp: 252, attack: 252, defense: 252 },
+				statRuleset: "mainSeries",
+			},
+		}),
+	).toThrow();
+	expect(() =>
+		AiDamageCalcInputSchema.parse({
+			...derivedManualInput,
+			attacker: {
+				...derivedManualInput.attacker,
+				effortValues: { hp: 33 },
+				statRuleset: "champions",
+			},
+		}),
+	).toThrow();
 });

--- a/test/damage/aiDamage.test.ts
+++ b/test/damage/aiDamage.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { AiDamageCalcInputSchema, calculateAiDamage, normalizeAiDamageCalcInput, safeCalculateAiDamage } from "../../src/aiDamage";
+
+const derivedManualInput = {
+  attacker: { statMode: "derived", types: ["Ghost", "Fairy"], baseStat: { hp: 55, attack: 55, defense: 55, specialAttack: 135, specialDefense: 135, speed: 135 }, level: 50, effortValues: { hp: 4, specialAttack: 252, speed: 252 }, individualValues: { attack: 0 }, statRuleset: "mainSeries", specialForm: "Tera" },
+  defender: { statMode: "manual", types: ["Ground", "Flying"], stats: { hp: 165, attack: 165, defense: 110, specialAttack: 112, specialDefense: 100, speed: 143 }, statStage: { specialDefense: -1 } },
+  move: { base: 95, type: "Fairy", category: "Special", target: "selectedTarget" },
+  field: { isDouble: true }
+} as const;
+
+test("schema accepts valid derived attacker + manual defender", () => {
+  expect(() => AiDamageCalcInputSchema.parse(derivedManualInput)).not.toThrow();
+});
+
+test("schema accepts minimal mechanical-default input", () => {
+  expect(() => AiDamageCalcInputSchema.parse({ attacker: { statMode: "derived", types: ["Normal"], baseStat: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, defender: { statMode: "manual", types: ["Normal"], stats: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, move: { base: 100, type: "Normal", category: "Special", target: "selectedTarget" } })).not.toThrow();
+});
+
+test("strict unknown-key rejection", () => {
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, x: 1 })).toThrow();
+});
+
+test("shorthand keys rejected", () => {
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, defender: { ...derivedManualInput.defender, stats: { hp: 1, atk: 2 } } })).toThrow();
+});
+
+test("isChampion and calcContext rejected", () => {
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, isChampion: true })).toThrow();
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, calcContext: {} })).toThrow();
+});
+
+test("manual mode uses stats as authoritative", () => {
+  const r1 = calculateAiDamage({ ...derivedManualInput, defender: { ...derivedManualInput.defender, baseStat: { hp: 1, attack: 1, defense: 1, specialAttack: 1, specialDefense: 1, speed: 1 }, effortValues: { hp: 0 } } });
+  const r2 = calculateAiDamage(derivedManualInput);
+  expect(r1.rolls).toEqual(r2.rolls);
+});
+
+test("default materialization works", () => {
+  const normalized = normalizeAiDamageCalcInput({ attacker: { statMode: "derived", types: ["Normal"], baseStat: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, defender: { statMode: "manual", types: ["Normal"], stats: { hp: 100, attack: 100, defense: 100, specialAttack: 100, specialDefense: 100, speed: 100 } }, move: { base: 100, type: "Normal", category: "Special", target: "selectedTarget" } });
+  expect(normalized.attacker.level).toBe(50);
+  expect(normalized.attacker.status).toBe("Healthy");
+  expect(normalized.attacker.effortValues.hp).toBe(0);
+  expect(normalized.attacker.individualValues.hp).toBe(31);
+  expect(normalized.field.isDouble).toBe(true);
+});
+
+test("output compatible with DamageResult and safe wrapper", () => {
+  const result = safeCalculateAiDamage(derivedManualInput);
+  expect(Array.isArray(result.rolls)).toBe(true);
+  expect(typeof result.koChance).toBe("number");
+  expect(result.factors.attacker).toBeObject();
+});
+
+test("invalid EV totals rejected based on statRuleset", () => {
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, attacker: { ...derivedManualInput.attacker, effortValues: { hp: 252, attack: 252, defense: 252 }, statRuleset: "mainSeries" } })).toThrow();
+  expect(() => AiDamageCalcInputSchema.parse({ ...derivedManualInput, attacker: { ...derivedManualInput.attacker, effortValues: { hp: 33 }, statRuleset: "champions" } })).toThrow();
+});


### PR DESCRIPTION
closes #148

### Motivation

- Implement the RFC-defined deterministic AI-facing damage calculation contract so external AI tooling can call a single deterministic engine surface.
- Provide strict, JSON-safe validation and best-effort mechanical checks to avoid LLM-driven invalid inputs while reusing the existing battle engine.

### Description

- Add `src/aiDamage.ts` which exports `AiDamageCalcInputSchema` / `AiDamageCalcInput`, `AiDamageCalcOutputSchema` / `AiDamageCalcOutput`, `NormalizedAiDamageCalcInput`, `normalizeAiDamageCalcInput(...)`, `calculateAiDamage(...)`, and `safeCalculateAiDamage(...)` using `zod` for strict validation. 
- Implement `derived` / `manual` discriminated semantics, canonical full stat keys (`hp`, `attack`, `defense`, `specialAttack`, `specialDefense`, `speed`), strict unknown-key rejection, and ruleset-aware EV validation (`champions` / `mainSeries`).
- Perform adapter-level materialization of mechanical defaults per the RFC (`level: 50`, EVs → `0`, IVs → `31`, stat stages → `0`, `status: "Healthy"`, `takenDamage: 0`, `specialForm: "None"`, `statRuleset: "champions"`, `field.isDouble: true`) and map inputs into 
existing engine types (`Pokemon`, `Battle`, `createMove`).
- Export the new AI module from the package entrypoint and add `test/damage/aiDamage.test.ts` covering schema acceptance/rejection, derived/manual behavior, defaulting, output compatibility, and EV-total validation.

### Testing

- Ran the new test suite with `bun test test/damage/aiDamage.test.ts` and all tests passed (`9` tests, `0` failures). 
- The tests exercise schema parsing, strictness rules, derived/manual authority, normalization defaults, output shape compatibility, and EV ruleset rejection behavior.
- No other automated test failures were introduced by these changes when running the added test file locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fb482ff4832fb852afecd70a0413)