### PR TITLE
Fix Changesets publish command after workspace migration

### DIFF
--- a/.changeset/fix-workspace-release.md
+++ b/.changeset/fix-workspace-release.md
@@ -1,0 +1,5 @@
+---
+"vgc_data_wrapper": patch
+---
+
+Fix the workspace release command so Changesets publishes from the repository root.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with: 
-          publish: bun run --filter vgc_data_wrapper publish
+          publish: bun run release
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "knip": "bun run --filter vgc_data_wrapper knip",
     "lint": "bun run --filter vgc_data_wrapper lint",
     "test-pokemon": "bun run --filter vgc_data_wrapper test-pokemon",
-    "test-damage": "bun run --filter vgc_data_wrapper test-damage"
+    "test-damage": "bun run --filter vgc_data_wrapper test-damage",
+    "release": "bun run --filter vgc_data_wrapper build && bunx changeset publish"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.27.1"
   }
 }

--- a/packages/vgc_data_wrapper/package.json
+++ b/packages/vgc_data_wrapper/package.json
@@ -4,7 +4,6 @@
 	"module": "dist/index.js",
 	"devDependencies": {
 		"@biomejs/biome": "2.4.12",
-		"@changesets/cli": "^2.27.1",
 		"@total-typescript/ts-reset": "^0.5.1",
 		"@types/bun": "latest",
 		"tsup": "^8.0.1"
@@ -32,8 +31,7 @@
 		"test-damage": "bun test **/damage/*.test.ts",
 		"test-pokemon": "bun test **/pokemon/*.test.ts",
 		"knip": "bunx knip",
-		"build": "tsup ./src/index.ts --format esm --dts ",
-		"publish": "bun run build && changeset publish"
+		"build": "tsup ./src/index.ts --format esm --dts "
 	},
 	"type": "module",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
### Motivation
- The workspace migration caused the Changesets action to call a package-level `publish` script inside `packages/vgc_data_wrapper`, which could not find the repository-level `.changeset` configuration and failed the auto-publish flow.
- The fix aligns the repo with the Changesets recommended pattern of building packages and running `changeset publish` from the repository root.

### Description
- Update `.github/workflows/publish.yml` to invoke a repository-level `release` script via `publish: bun run release` so `changeset publish` runs from the root where `.changeset` lives.
- Add a root `release` script to `package.json` as `bun run --filter vgc_data_wrapper build && bunx changeset publish` to build the package then publish from the repository context.
- Move `@changesets/cli` from `packages/vgc_data_wrapper` into the root `devDependencies` and remove the nested `publish` script from the package to keep release tooling at the workspace root.
- Leave the package `build` script in `packages/vgc_data_wrapper` intact so package outputs remain unchanged.

### Testing
- Ran compile and tooling checks with `bunx tsc`, `bun knip`, `bun lint`, and root `bun run --filter vgc_data_wrapper build`, and these completed successfully (knip emitted a minor configuration hint).
- Ran unit test suites with `bun test` via `bun run --filter vgc_data_wrapper test-pokemon` and `bun run --filter vgc_data_wrapper test-damage`, and all tests passed.
- Verified `bunx changeset --help` and basic build outputs; `bunx changeset status` could not complete in this isolated checkout because the runner has no local or remote-tracking `main` ref, which prevented divergence analysis but does not indicate misconfiguration of the repository-level `.changeset`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5ecd0cac832f9886dbadcd64ef00)