### PR TITLE
Introduce effectiveMoveType helper and apply to damage/type/power calculations

### DIFF
--- a/.changeset/skin-effective-type-fixes.md
+++ b/.changeset/skin-effective-type-fixes.md
@@ -1,0 +1,5 @@
+---
+"vgc_data_wrapper": patch
+---
+
+Fix skin ability effective move type interactions with terrain, aura, type effectiveness, and defensive Filter/Solid Rock modifiers.

--- a/packages/vgc_data_wrapper/src/damage/battle.ts
+++ b/packages/vgc_data_wrapper/src/damage/battle.ts
@@ -580,11 +580,12 @@ function getTypeModifier({
 	}
 	// use original type when tera stellar
 	if (checkTeraWIthTypeMatch(defender, "Stellar")) {
+		const effectiveMoveType = getEffectiveMoveType(attacker, move);
 		return {
-			operator: getEffectivenessOnPokemon(
-				getEffectiveMoveType(attacker, move),
-				defender.types,
-			),
+			operator:
+				effectiveMoveType === "Stellar"
+					? 1
+					: getEffectivenessOnPokemon(effectiveMoveType, defender.types),
 		};
 	}
 
@@ -616,11 +617,15 @@ function getTypeModifier({
 					},
 		};
 	}
+	const effectiveMoveType = getEffectiveMoveType(attacker, move);
 	return {
-		operator: getEffectivenessOnPokemon(
-			getEffectiveMoveType(attacker, move),
-			getPokemonCurrentType(defender),
-		),
+		operator:
+			effectiveMoveType === "Stellar"
+				? 1
+				: getEffectivenessOnPokemon(
+						effectiveMoveType,
+						getPokemonCurrentType(defender),
+					),
 		factors: defender.isTera()
 			? {
 					defender: {
@@ -822,10 +827,14 @@ function modifyByDefenderAbility({
 	}
 
 	// Solid Rock && Filter
-	const effectiveness = getEffectivenessOnPokemon(
-		getEffectiveMoveType(attacker, move),
-		defender.isTera() ? [defender.teraType] : defender.types,
-	);
+	const effectiveMoveType = getEffectiveMoveType(attacker, move);
+	const effectiveness =
+		effectiveMoveType === "Stellar"
+			? 1
+			: getEffectivenessOnPokemon(
+					effectiveMoveType,
+					defender.isTera() ? [defender.teraType] : defender.types,
+				);
 	if (
 		(defender.ability === "Solid Rock" || defender.ability === "Filter") &&
 		effectiveness > 1

--- a/packages/vgc_data_wrapper/src/damage/battle.ts
+++ b/packages/vgc_data_wrapper/src/damage/battle.ts
@@ -790,9 +790,10 @@ function modifyByAttackerAbility({
 }
 
 function modifyByDefenderAbility({
+	attacker,
 	defender,
 	move,
-}: Pick<BattleStatus, "defender" | "move">): TemporalFactor {
+}: Pick<BattleStatus, "attacker" | "defender" | "move">): TemporalFactor {
 	const getFactor = createFactorHelper({
 		defender: {
 			ability: true,
@@ -822,7 +823,7 @@ function modifyByDefenderAbility({
 
 	// Solid Rock && Filter
 	const effectiveness = getEffectivenessOnPokemon(
-		move.type,
+		getEffectiveMoveType(attacker, move),
 		defender.isTera() ? [defender.teraType] : defender.types,
 	);
 	if (

--- a/packages/vgc_data_wrapper/src/damage/battle.ts
+++ b/packages/vgc_data_wrapper/src/damage/battle.ts
@@ -1,5 +1,4 @@
 import type { Pokemon } from "../pokemon";
-import type { Ability } from "../pokemon/typeHelper";
 import { isTerapagosStellar } from "../pokemon/utils";
 import type { RecursivePartial } from "../typeUtils";
 import { getAttack } from "./attack";
@@ -8,9 +7,12 @@ import type {
 	BattleStatus,
 	DamageResult,
 	Move,
-	Type,
 } from "./config";
 import { getDefense } from "./defense";
+import {
+	getEffectiveMoveType,
+	getSkinAbilityMoveType,
+} from "./effectiveMoveType";
 import { getPower } from "./power";
 import { getEffectivenessOnPokemon } from "./type";
 import {
@@ -19,14 +21,6 @@ import {
 	mergeFactorList,
 	pipeModifierHelper,
 } from "./utils";
-
-const SKIN_ABILITIES: Partial<Record<Ability, Type>> = {
-	Pixilate: "Fairy",
-	Refrigerate: "Ice",
-	Aerilate: "Flying",
-	Dragonize: "Dragon",
-	Galvanize: "Electric",
-};
 
 interface IBattle extends Partial<BattleStatus> {
 	getDamage: () => DamageResult;
@@ -341,10 +335,8 @@ function modifyBySameType(
 		}
 	}
 	// skin abilities (Pixilate/Refrigerate/Aerilate/Dragonize/Galvanize)
-	const skinType = attacker.ability
-		? SKIN_ABILITIES[attacker.ability]
-		: undefined;
-	if (skinType && move.type === "Normal") {
+	const skinType = getSkinAbilityMoveType(attacker, move);
+	if (skinType) {
 		factors = mergeFactorList(factors, {
 			attacker: {
 				ability: true,
@@ -487,10 +479,8 @@ function getTypeModifier({
 		};
 	}
 	// skins (Pixilate/Refrigerate/Aerilate/Dragonize/Galvanize)
-	const skinType = attacker.ability
-		? SKIN_ABILITIES[attacker.ability]
-		: undefined;
-	if (skinType && move.type === "Normal") {
+	const skinType = getSkinAbilityMoveType(attacker, move);
+	if (skinType) {
 		if (!defender.isTera() || defender.teraType === "Stellar") {
 			// use original type
 			return {
@@ -590,7 +580,12 @@ function getTypeModifier({
 	}
 	// use original type when tera stellar
 	if (checkTeraWIthTypeMatch(defender, "Stellar")) {
-		return { operator: getEffectivenessOnPokemon(move.type, defender.types) };
+		return {
+			operator: getEffectivenessOnPokemon(
+				getEffectiveMoveType(attacker, move),
+				defender.types,
+			),
+		};
 	}
 
 	// Scrappy ability makes Normal and Fighting moves hit Ghost types
@@ -623,7 +618,7 @@ function getTypeModifier({
 	}
 	return {
 		operator: getEffectivenessOnPokemon(
-			move.type,
+			getEffectiveMoveType(attacker, move),
 			getPokemonCurrentType(defender),
 		),
 		factors: defender.isTera()

--- a/packages/vgc_data_wrapper/src/damage/effectiveMoveType.ts
+++ b/packages/vgc_data_wrapper/src/damage/effectiveMoveType.ts
@@ -1,0 +1,24 @@
+import type { Pokemon } from "../pokemon";
+import type { Ability } from "../pokemon/typeHelper";
+import type { Move, Type } from "./config";
+
+const SKIN_ABILITY_TYPES: Partial<Record<Ability, Type>> = {
+	Pixilate: "Fairy",
+	Refrigerate: "Ice",
+	Aerilate: "Flying",
+	Dragonize: "Dragon",
+	Galvanize: "Electric",
+};
+
+export function getEffectiveMoveType(attacker: Pokemon, move: Move): Type {
+	return getSkinAbilityMoveType(attacker, move) ?? move.type;
+}
+
+export function getSkinAbilityMoveType(
+	attacker: Pokemon,
+	move: Move,
+): Type | undefined {
+	return move.type === "Normal" && attacker.ability
+		? SKIN_ABILITY_TYPES[attacker.ability]
+		: undefined;
+}

--- a/packages/vgc_data_wrapper/src/damage/effectiveMoveType.ts
+++ b/packages/vgc_data_wrapper/src/damage/effectiveMoveType.ts
@@ -1,6 +1,6 @@
 import type { Pokemon } from "../pokemon";
 import type { Ability } from "../pokemon/typeHelper";
-import type { Move, Type } from "./config";
+import type { Move, TeraTypes, Type } from "./config";
 
 const SKIN_ABILITY_TYPES: Partial<Record<Ability, Type>> = {
 	Pixilate: "Fairy",
@@ -10,8 +10,11 @@ const SKIN_ABILITY_TYPES: Partial<Record<Ability, Type>> = {
 	Galvanize: "Electric",
 };
 
-export function getEffectiveMoveType(attacker: Pokemon, move: Move): Type {
-	return getSkinAbilityMoveType(attacker, move) ?? move.type;
+export function getEffectiveMoveType(attacker: Pokemon, move: Move): TeraTypes {
+	const skinAbilityMoveType = getSkinAbilityMoveType(attacker, move);
+	if (skinAbilityMoveType) return skinAbilityMoveType;
+	if (move.type === "Stellar") return "Stellar";
+	return move.type;
 }
 
 export function getSkinAbilityMoveType(

--- a/packages/vgc_data_wrapper/src/damage/power.ts
+++ b/packages/vgc_data_wrapper/src/damage/power.ts
@@ -2,6 +2,10 @@ import { getBasePower } from "./basePower";
 import { createFactorHelper, type TemporalFactor } from "./battle";
 import type { BattleStatus } from "./config";
 import {
+	getEffectiveMoveType,
+	getSkinAbilityMoveType,
+} from "./effectiveMoveType";
+import {
 	checkTeraWIthTypeMatch,
 	isGrounded,
 	mergeFactorList,
@@ -87,19 +91,7 @@ function modifyByAttackerAbility({
 		return getFactor(1 + 0.1 * 3);
 	}
 	// skins
-	if (
-		// Refrigerate
-		(attacker.ability === "Refrigerate" ||
-			// Pixilate
-			attacker.ability === "Pixilate" ||
-			// Dragonize
-			attacker.ability === "Dragonize" ||
-			// Aerilate
-			attacker.ability === "Aerilate" ||
-			// Galvanize
-			attacker.ability === "Galvanize") &&
-		move.type === "Normal"
-	) {
+	if (getSkinAbilityMoveType(attacker, move)) {
 		return getFactor(1.2);
 	}
 	// iron fist
@@ -381,16 +373,17 @@ function modifyByTerrain({
 			terrain: true,
 		},
 	});
+	const effectiveMoveType = getEffectiveMoveType(attacker, move);
 	if (
 		isGrounded(attacker) &&
-		((move.type === "Electric" && field?.terrain === "Electric") ||
-			(move.type === "Psychic" && field?.terrain === "Psychic") ||
-			(move.type === "Grass" && field?.terrain === "Grassy"))
+		((effectiveMoveType === "Electric" && field?.terrain === "Electric") ||
+			(effectiveMoveType === "Psychic" && field?.terrain === "Psychic") ||
+			(effectiveMoveType === "Grass" && field?.terrain === "Grassy"))
 	) {
 		return getFactor(1.3);
 	}
 	if (
-		move.type === "Dragon" &&
+		effectiveMoveType === "Dragon" &&
 		field?.terrain === "Misty" &&
 		isGrounded(defender)
 	) {
@@ -404,12 +397,10 @@ function modifyByAura({
 	field,
 	attacker,
 }: Pick<BattleStatus, "move" | "field" | "attacker">): TemporalFactor {
+	const effectiveMoveType = getEffectiveMoveType(attacker, move);
 	const auraAffected =
-		(move.type === "Dark" && field?.aura?.includes("Dark")) ||
-		(move.type === "Fairy" && field?.aura?.includes("Fairy")) ||
-		(move.type === "Normal" &&
-			attacker.ability === "Pixilate" &&
-			field?.aura?.includes("Fairy"));
+		(effectiveMoveType === "Dark" && field?.aura?.includes("Dark")) ||
+		(effectiveMoveType === "Fairy" && field?.aura?.includes("Fairy"));
 	const isAuraBreak = field?.aura?.includes("Aura Break");
 	return auraAffected
 		? {

--- a/packages/vgc_data_wrapper/test/damage/ability.test.ts
+++ b/packages/vgc_data_wrapper/test/damage/ability.test.ts
@@ -237,21 +237,34 @@ test("Pixilate Normal move triggers Filter when the effective Fairy type is supe
 		baseStat: { hp: 91, specialDefense: 100 },
 		ability: "Filter",
 	});
+	const nonFilterDefender = genTestMon({
+		types: ["Dragon", "Flying"],
+		baseStat: { hp: 91, specialDefense: 100 },
+	});
 	const move = createMove({
 		base: 90,
 		type: "Normal",
 		category: "Special",
 		target: "allAdjacentFoes",
 	});
-	const battle = new Battle({ attacker, defender, move });
-	const damage = battle.getDamage();
-	const actual = getDamangeNumberFromResult(damage);
-	const expected = [
+	const nonFilterDamage = new Battle({
+		attacker,
+		defender: nonFilterDefender,
+		move,
+	}).getDamage();
+	const filterDamage = new Battle({ attacker, defender, move }).getDamage();
+
+	expect(getDamangeNumberFromResult(nonFilterDamage)).toEqual([
+		102, 102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116,
+		120,
+	]);
+	expect(getDamangeNumberFromResult(filterDamage)).toEqual([
 		76, 76, 76, 78, 78, 81, 81, 81, 82, 82, 85, 85, 85, 87, 87, 90,
-	];
-	expect(actual).toEqual(expected);
-	expect(damage.factors.attacker.ability).toEqual(true);
-	expect(damage.factors.defender.ability).toEqual(true);
+	]);
+	expect(nonFilterDamage.factors.attacker.ability).toEqual(true);
+	expect(nonFilterDamage.factors.defender.ability).toBeUndefined();
+	expect(filterDamage.factors.attacker.ability).toEqual(true);
+	expect(filterDamage.factors.defender.ability).toEqual(true);
 });
 
 test("Adaptability", () => {

--- a/packages/vgc_data_wrapper/test/damage/ability.test.ts
+++ b/packages/vgc_data_wrapper/test/damage/ability.test.ts
@@ -226,6 +226,34 @@ test("Dragonize", () => {
 	expect(damage.factors.attacker.ability).toEqual(true);
 });
 
+test("Pixilate Normal move triggers Filter when the effective Fairy type is super effective", () => {
+	const attacker = genTestMon({
+		types: ["Fairy"],
+		baseStat: { specialAttack: 110 },
+		ability: "Pixilate",
+	});
+	const defender = genTestMon({
+		types: ["Dragon", "Flying"],
+		baseStat: { hp: 91, specialDefense: 100 },
+		ability: "Filter",
+	});
+	const move = createMove({
+		base: 90,
+		type: "Normal",
+		category: "Special",
+		target: "allAdjacentFoes",
+	});
+	const battle = new Battle({ attacker, defender, move });
+	const damage = battle.getDamage();
+	const actual = getDamangeNumberFromResult(damage);
+	const expected = [
+		76, 76, 76, 78, 78, 81, 81, 81, 82, 82, 85, 85, 85, 87, 87, 90,
+	];
+	expect(actual).toEqual(expected);
+	expect(damage.factors.attacker.ability).toEqual(true);
+	expect(damage.factors.defender.ability).toEqual(true);
+});
+
 test("Adaptability", () => {
 	const attacker = genTestMon({
 		types: ["Poison"],

--- a/packages/vgc_data_wrapper/test/damage/terrain.test.ts
+++ b/packages/vgc_data_wrapper/test/damage/terrain.test.ts
@@ -194,3 +194,73 @@ test("Psyblade damage changes when a Flying attacker is grounded by Iron Ball", 
 	]);
 	expect(groundedDamage).not.toEqual(ungroundedDamage);
 });
+
+test("Dragonize Normal move is reduced by Misty Terrain against a grounded defender", () => {
+	const attacker = genTestMon({
+		types: ["Water"],
+		ability: "Dragonize",
+		baseStat: { specialAttack: 100 },
+	});
+	const defender = genTestMon({
+		types: ["Normal"],
+		baseStat: { hp: 100, specialDefense: 100 },
+	});
+	const move = createMove({
+		base: 100,
+		type: "Normal",
+		category: "Special",
+	});
+	const noTerrainDamage = getDamangeNumberFromResult(
+		new Battle({ attacker, defender, move }).getDamage(),
+	);
+	const mistyTerrainDamage = getDamangeNumberFromResult(
+		new Battle({
+			attacker,
+			defender,
+			move,
+			field: { terrain: "Misty" },
+		}).getDamage(),
+	);
+
+	expect(noTerrainDamage).toEqual([
+		45, 46, 46, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 52, 53, 54,
+	]);
+	expect(mistyTerrainDamage).toEqual([
+		23, 24, 24, 24, 24, 25, 25, 25, 26, 26, 26, 26, 27, 27, 27, 28,
+	]);
+});
+
+test("Galvanize Normal move is boosted by Electric Terrain from a grounded attacker", () => {
+	const attacker = genTestMon({
+		types: ["Normal"],
+		ability: "Galvanize",
+		baseStat: { specialAttack: 100 },
+	});
+	const defender = genTestMon({
+		types: ["Normal"],
+		baseStat: { hp: 100, specialDefense: 100 },
+	});
+	const move = createMove({
+		base: 100,
+		type: "Normal",
+		category: "Special",
+	});
+	const noTerrainDamage = getDamangeNumberFromResult(
+		new Battle({ attacker, defender, move }).getDamage(),
+	);
+	const electricTerrainDamage = getDamangeNumberFromResult(
+		new Battle({
+			attacker,
+			defender,
+			move,
+			field: { terrain: "Electric" },
+		}).getDamage(),
+	);
+
+	expect(noTerrainDamage).toEqual([
+		67, 69, 69, 70, 72, 72, 73, 73, 75, 75, 76, 76, 78, 78, 79, 81,
+	]);
+	expect(electricTerrainDamage).toEqual([
+		88, 90, 90, 91, 93, 94, 94, 96, 97, 97, 99, 100, 100, 102, 103, 105,
+	]);
+});


### PR DESCRIPTION
### Motivation

- Centralize logic for skin abilities (Pixilate/Refrigerate/Aerilate/Dragonize/Galvanize) and make move type resolution consistent across damage, type effectiveness, and power calculations.
- Ensure terrain, aura, and tera interactions use the effective move type when skin abilities or similar transformations apply.

### Description

- Add `effectiveMoveType.ts` with `getEffectiveMoveType` and `getSkinAbilityMoveType` and move the skin-ability-to-type mapping into it.
- Replace inline `SKIN_ABILITIES` usage in `battle.ts` and `power.ts` with calls to `getSkinAbilityMoveType` and use `getEffectiveMoveType` where the effective move type should be considered (terrain, aura, and certain type-effectiveness branches including tera Stellar cases).
- Update type modifier logic to compute effectiveness using `getEffectiveMoveType` in appropriate branches and keep ability factors when skin abilities apply.
- Remove the duplicated `SKIN_ABILITIES` constant and adjust affected functions to rely on the new helper.
- Add tests in `packages/vgc_data_wrapper/test/damage/terrain.test.ts` covering `Dragonize` under Misty Terrain and `Galvanize` under Electric Terrain to validate effective type interactions.

### Testing

- Ran the modified terrain tests with `yarn test packages/vgc_data_wrapper/test/damage/terrain.test.ts`, and the new and existing assertions passed.
- Ran the package test suite for `packages/vgc_data_wrapper` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a2d6d9578832f8caeb9426ffe193c)