### PR TITLE
Add Pixilate STAB regression coverage

### DIFF
--- a/.changeset/skin-ability-stab-patch.md
+++ b/.changeset/skin-ability-stab-patch.md
@@ -1,0 +1,5 @@
+---
+"vgc_data_wrapper": patch
+---
+
+Fix skin ability STAB calculation to use the converted move type, preventing converted Normal moves from retaining Normal-type STAB while preserving STAB for matching converted types like Pixilate Fairy attacks.

--- a/packages/vgc_data_wrapper/src/damage/battle.ts
+++ b/packages/vgc_data_wrapper/src/damage/battle.ts
@@ -314,7 +314,7 @@ function modifyBySameType(
 	let factors: TemporalFactor["factors"] = {};
 	const effectiveMoveType = getEffectiveMoveType(attacker, move, field);
 	const skinType = getSkinAbilityMoveType(attacker, move);
-	const stabMoveType = skinType ? move.type : effectiveMoveType;
+	const stabMoveType = effectiveMoveType;
 	// Protean
 	if (attacker.ability === "Protean") {
 		factors = mergeFactorList(factors, {

--- a/packages/vgc_data_wrapper/test/damage/ability.test.ts
+++ b/packages/vgc_data_wrapper/test/damage/ability.test.ts
@@ -128,6 +128,50 @@ test("Pixilate", () => {
 	expect(nonNormalDamage.factors.attacker.ability).toBeUndefined();
 });
 
+test("Pixilate Normal move uses converted Fairy type for STAB", () => {
+	const defender = genTestMon({
+		types: ["Dragon", "Flying"],
+		baseStat: { hp: 91, specialDefense: 100 },
+	});
+	const move = createMove({
+		base: 90,
+		type: "Normal",
+		category: "Special",
+		target: "allAdjacentFoes",
+	});
+	const normalTypeAttacker = genTestMon({
+		types: ["Normal"],
+		baseStat: { specialAttack: 110 },
+		ability: "Pixilate",
+	});
+	const fairyTypeAttacker = genTestMon({
+		types: ["Fairy"],
+		baseStat: { specialAttack: 110 },
+		ability: "Pixilate",
+	});
+
+	const normalTypeDamage = new Battle({
+		attacker: normalTypeAttacker,
+		defender,
+		move,
+	}).getDamage();
+	const fairyTypeDamage = new Battle({
+		attacker: fairyTypeAttacker,
+		defender,
+		move,
+	}).getDamage();
+
+	expect(getDamangeNumberFromResult(normalTypeDamage)).toEqual([
+		68, 68, 68, 70, 70, 72, 72, 72, 74, 74, 76, 76, 76, 78, 78, 80,
+	]);
+	expect(getDamangeNumberFromResult(fairyTypeDamage)).toEqual([
+		102, 102, 102, 104, 104, 108, 108, 108, 110, 110, 114, 114, 114, 116, 116,
+		120,
+	]);
+	expect(normalTypeDamage.factors.attacker.ability).toEqual(true);
+	expect(fairyTypeDamage.factors.attacker.ability).toEqual(true);
+});
+
 test("Refrigerate", () => {
 	const megaGlalie = genTestMon({
 		types: ["Ice"],

--- a/packages/vgc_data_wrapper/test/damage/terrain.test.ts
+++ b/packages/vgc_data_wrapper/test/damage/terrain.test.ts
@@ -230,7 +230,7 @@ test("Dragonize Normal move is reduced by Misty Terrain against a grounded defen
 	]);
 });
 
-test("Galvanize Normal move is boosted by Electric Terrain from a grounded attacker", () => {
+test("Galvanize Normal move uses converted Electric type for STAB and terrain", () => {
 	const attacker = genTestMon({
 		types: ["Normal"],
 		ability: "Galvanize",
@@ -258,10 +258,10 @@ test("Galvanize Normal move is boosted by Electric Terrain from a grounded attac
 	);
 
 	expect(noTerrainDamage).toEqual([
-		67, 69, 69, 70, 72, 72, 73, 73, 75, 75, 76, 76, 78, 78, 79, 81,
+		45, 46, 46, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 52, 53, 54,
 	]);
 	expect(electricTerrainDamage).toEqual([
-		88, 90, 90, 91, 93, 94, 94, 96, 97, 97, 99, 100, 100, 102, 103, 105,
+		59, 60, 60, 61, 62, 63, 63, 64, 65, 65, 66, 67, 67, 68, 69, 70,
 	]);
 });
 


### PR DESCRIPTION
### Motivation
- Add explicit Pixilate/Fairy STAB regression coverage as a follow-up to the skin-ability STAB fix to ensure converted Normal moves use the converted type for STAB only when appropriate.

### Description
- Add a new test `Pixilate Normal move uses converted Fairy type for STAB` to `packages/vgc_data_wrapper/test/damage/ability.test.ts` that compares damage from a Normal-type Pixilate attacker and a Fairy-type Pixilate attacker against a Dragon/Flying defender and asserts the expected damage rolls and ability factors.

### Testing
- Ran `bun install` then `bun test packages/vgc_data_wrapper/test/damage/ability.test.ts`, `bun run --filter vgc_data_wrapper lint`, `bun knip`, `bun lint`, `bun test-pokemon`, and `bun run --filter vgc_data_wrapper check`, and all commands completed successfully (tests and checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e0ff00164832fbec7344eaf470a99)